### PR TITLE
fix: fix the yaml syntax error because of multiple if statements and add codeowners files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Please do not attempt to edit this file without the direct consent from the DevOps team. This file is managed centrally.
+# Contact @scott45
+
+* @scott45

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -14,8 +14,7 @@ on:
 
 jobs:
   Sync_All_Repos_Common_Workflows:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    if: github.event.pull_request.merged == true  # Run this job only if the pull request was merged
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest  # Use the latest Ubuntu runner for the job
     steps:
       - name: Checkout Central Workflows Repo  # Step to checkout the repository containing the central workflows


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Fix invalid yaml syntax error and add CODEOWNERS file

## Why are we doing this?
Workflow file was showing invalid syntax error messages during testing because of the two if statements.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done