### PR TITLE
fix: add github action workflow to validate package.json

### DIFF
--- a/.github/workflows/validate-package.json.yml
+++ b/.github/workflows/validate-package.json.yml
@@ -1,0 +1,55 @@
+name: Validate package.json
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate-package-json:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Validate package.json
+      id: validate-package
+      run: |
+        # Check if package.json exists
+        if [ ! -f package.json ]; then
+          echo "package.json not found!"
+          exit 1
+        fi
+
+        # Validate the required fields
+        REQUIRED_NAME="Tazama"
+        REQUIRED_EMAIL="engineering@tazama.org"
+        REQUIRED_URL="tazama.org"
+
+        NAME=$(jq -r '.name' package.json)
+        EMAIL=$(jq -r '.author.email' package.json)
+        URL=$(jq -r '.author.url' package.json)
+
+        if [ "$NAME" != "$REQUIRED_NAME" ]; then
+          echo "Error: 'name' field in package.json should be '$REQUIRED_NAME', but found '$NAME'"
+          exit 1
+        fi
+
+        if [ "$EMAIL" != "$REQUIRED_EMAIL" ]; then
+          echo "Error: 'email' field in package.json should be '$REQUIRED_EMAIL', but found '$EMAIL'"
+          exit 1
+        fi
+
+        if [ "$URL" != "$REQUIRED_URL" ]; then
+          echo "Error: 'url' field in package.json should be '$REQUIRED_URL', but found '$URL'"
+          exit 1
+        fi
+
+        echo "package.json validation successful!"
+
+    - name: Output validation result
+      run: echo "Validation completed successfully!"

--- a/workflow-docs/validate-package-json.md
+++ b/workflow-docs/validate-package-json.md
@@ -1,0 +1,26 @@
+## Workflow Name: PR Conventional Commit Validation
+
+#### Purpose: 
+
+- This GitHub Action workflow is designed to validate the `package.json` file when a PR is submitted to check that it is as defined in the contribution guide
+
+#### Trigger Events
+
+Trigger: The workflow is triggered on push and pull_request events to the main branch.
+
+#### Jobs
+
+Checkout Repository: The repository is checked out using the actions/checkout@v3 action.
+
+Validate package.json:
+
+- The script first checks if package.json exists.
+
+- It then uses jq to extract the name, author.email, and author.url fields from package.json.
+
+- The script compares these fields against the required values (Tazama, engineering@tazama.org, and tazama.org).
+
+- If any of the fields do not match, the script exits with an error message.
+
+- Output Validation Result: If the validation is successful, a success message is printed.
+


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Add github action workflow to validate package.json

## Why are we doing this?
Aligning with the contribution guide requirements

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done