### PR TITLE
fix: upgrade codacy-analysis-cli-action to v4.4.7 (High severity parse error)

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@3ff8e64eb4b714c4bee91b7b4eea31c6fc2c4f93
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations


### PR DESCRIPTION
## Problem

The Codacy scan is failing with:

```
High not a member of Level: DownField(level),DownArray,DownField(data)
```

The Codacy Patterns API now returns `High` and `Critical` as severity levels. The CLI version pinned at `3ff8e64` pre-dates this change and crashes when it encounters them.

## Fix

Upgrade `codacy/codacy-analysis-cli-action` from `3ff8e64` to `v4.4.7` (`562ee3e`), which handles the new severity levels.

```diff
- uses: codacy/codacy-analysis-cli-action@3ff8e64eb4b714c4bee91b7b4eea31c6fc2c4f93
+ uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
```

## Propagation

`codacy.yml` **is** in the sync list (not excluded). Merging this PR and triggering `sync-workflows.yml` will propagate the fix to all `tazama-lf` service repos automatically.

## Related

Part of #23 (partially — the broader workflow hygiene work continues on a separate branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the repository's code analysis workflow to a newer action version to keep tooling current.
  * No changes to runtime behavior, app features, or public interfaces.
  * No changes to workflow triggers, inputs, permissions, or SARIF upload configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->