### PR TITLE
feat: add canonical publish.yml and extend sync for library repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Justus-at-Tazama @Sandy-at-Tazama @scott45
+* @tazama-lf/core-codeowners @tazama-lf/community-codeowners

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,15 @@ jobs:
         run: npm run build
 
       - name: Publish package
-        run: npm publish
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            # Prerelease version (e.g. 1.2.3-rc.1): publish under the 'rc' dist-tag
+            # so it does not become the default 'latest' install target.
+            npm publish --tag rc
+          else
+            npm publish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This workflow publishes an npm package to the GitHub Package Registry (@tazama-lf scope).
+#
+# Versioning policy:
+#   Developers are expected to set the version in package.json manually and publish the RC
+#   package before (or when) creating a PR. This workflow_dispatch trigger is a safety net
+#   for republishing from CI without a local environment.
+#
+# Automatic latest-tag publishing (strip -rc.X, publish on merge to main) is tracked in:
+#   https://github.com/tazama-lf/workflows/issues/27
+#
+# Please do not attempt to edit this flow without the direct consent from the DevOps team.
+# This file is managed centrally.
+
+name: Publish npm package to GitHub Packages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_LIB }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com/'
+          scope: '@tazama-lf'
+
+      - name: Set up npm authentication
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN_LIB }}" >> ~/.npmrc
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish package
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+
+      # Send Slack notification — requires SLACK_WEBHOOK_URL org/repo secret
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST -H 'Content-type: application/json' --data '{
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "New npm package published :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Repository:*\nhttps://github.com/${{ github.repository }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Triggered by:*\n${{ github.actor }}"
+                  }
+                ]
+              }
+            ]
+          }' "$SLACK_WEBHOOK_URL" || true

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -119,11 +119,15 @@ jobs:
           rm temp-workflows/sync-workflows.yml  # Remove the sync-workflows.yml to avoid recursive syncing
           rm -f temp-workflows/node.js.yml  # Remove per-repo CI workflow to avoid overwriting repo-specific benchmarks
 
+          # Helper: check membership in a newline-delimited list (YAML block scalar)
+          # Space-delimited single-line vars (SPECIFIC_FILES) use the [[ =~ ]] pattern directly.
+          in_list() { echo "$2" | grep -Fxq "$1"; }
+
           for repo in $REPOS; do
             # Library repos (PUBLISH_REPOS) are in tazama-lf org.
             # Service repos are currently in frmscoe org.
             # TODO: Migrate all service repos to tazama-lf and update this logic — tracked in tazama-lf/workflows#28
-            if [[ " ${PUBLISH_REPOS} " =~ " ${repo} " ]]; then
+            if in_list "$repo" "$PUBLISH_REPOS"; then
               ORG="tazama-lf"
             else
               ORG="frmscoe"
@@ -149,17 +153,37 @@ jobs:
             for file in temp-workflows/*; do
               filename=$(basename "$file")
               # Docker workflows: skip for repos that don't build Docker images
-              if [[ " ${SPECIFIC_REPOS} " =~ " ${repo} " ]] && [[ " ${SPECIFIC_FILES} " =~ " ${filename} " ]]; then
+              if in_list "$repo" "$SPECIFIC_REPOS" && [[ " ${SPECIFIC_FILES} " =~ " ${filename} " ]]; then
                 continue
               fi
               # publish.yml: only copy to designated library repos
-              if [[ "${filename}" == "publish.yml" ]] && ! [[ " ${PUBLISH_REPOS} " =~ " ${repo} " ]]; then
+              if [[ "${filename}" == "publish.yml" ]] && ! in_list "$repo" "$PUBLISH_REPOS"; then
                 continue
               fi
               cp -r "$file" "$repo/.github/workflows/"
             done
+
+            cd $repo
+            git add .
+            git commit -m "ci: sync workflows from central-workflows ${SIGNED_OFF_BY}" || echo "No changes to commit"
+            git push origin sync-workflows-update || git push origin sync-workflows-update --force
+
+            # Clear the GITHUB_TOKEN environment variable and use a temporary file for gh authentication
+            echo "${{ secrets.GH_TOKEN }}" > /tmp/gh_token
+            unset GITHUB_TOKEN
+            gh auth login --with-token < /tmp/gh_token
+
+            # Create the PR with reviewers
+            IFS=',' read -ra REVIEWERS <<< "${PR_REVIEWERS}"
+            REVIEWERS_ARGS=""
+            for reviewer in "${REVIEWERS[@]}"; do
+              REVIEWERS_ARGS+="--reviewer $reviewer "
+            done
+
+            gh pr create --title "ci: sync workflows from central-workflows" --body "This PR syncs workflows from the central-workflows repository. ${SIGNED_OFF_BY}" --base dev --head sync-workflows-update $REVIEWERS_ARGS || echo "PR already exists, updating existing PR"
+
             # Cleanup
             rm /tmp/gh_token
-            
+
             cd ..
           done

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -67,9 +67,17 @@ jobs:
             frms-coe-lib
             frms-coe-startup-lib
             auth-lib
+            auth-lib-provider-keycloak
             rule-901
-          SPECIFIC_FILES: dockerhub-image-build.yml dockerhub-image-build-rc.yml  # List of specific files not to copy to certain repositories
-          SPECIFIC_REPOS: |  # List of specific repositories needing specific files not included
+            rule-902
+            tcs-lib
+            relay-service-integration-nats
+            relay-service-integration-rest
+            relay-service-integration-kafka
+            relay-service-integration-rabbitmq
+            audit-lib
+          SPECIFIC_FILES: dockerhub-image-build.yml dockerhub-image-build-rc.yml  # Docker workflows: only for repos that build Docker images (i.e. not in SPECIFIC_REPOS)
+          SPECIFIC_REPOS: |  # Repos that do NOT build Docker images — receive all workflows except SPECIFIC_FILES
             relay-service
             lumberjack
             batch-ppa
@@ -78,15 +86,52 @@ jobs:
             frms-coe-lib
             frms-coe-startup-lib
             auth-lib
+            auth-lib-provider-keycloak
             rule-901
+            rule-902
+            tcs-lib
+            relay-service-integration-nats
+            relay-service-integration-rest
+            relay-service-integration-kafka
+            relay-service-integration-rabbitmq
+            audit-lib
+          PUBLISH_REPOS: |  # Library repos that publish npm packages — the only repos that receive publish.yml
+            frms-coe-lib
+            frms-coe-startup-lib
+            auth-lib
+            auth-lib-provider-keycloak
+            rule-901
+            rule-902
+            tcs-lib
+            relay-service-integration-nats
+            relay-service-integration-rest
+            relay-service-integration-kafka
+            relay-service-integration-rabbitmq
+            audit-lib
           PR_REVIEWERS: ${{ secrets.GH_USERNAME }}  # List of reviewers
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           SIGNED_OFF_BY="Signed-off-by: ${{ env.PR_AUTHOR_NAME_FULL }} <${{ env.PR_AUTHOR_EMAIL }}>"
+
+          # Build the temp-workflows bundle once, outside the repo loop
+          mkdir -p temp-workflows
+          cp -r .github/workflows/* temp-workflows/
+          rm temp-workflows/sync-workflows.yml  # Remove the sync-workflows.yml to avoid recursive syncing
+          rm -f temp-workflows/node.js.yml  # Remove per-repo CI workflow to avoid overwriting repo-specific benchmarks
+
           for repo in $REPOS; do
-            git clone https://github.com/frmscoe/$repo.git
+            # Library repos (PUBLISH_REPOS) are in tazama-lf org.
+            # Service repos are currently in frmscoe org.
+            # TODO: Migrate all service repos to tazama-lf and update this logic — tracked in tazama-lf/workflows#28
+            if [[ " ${PUBLISH_REPOS} " =~ " ${repo} " ]]; then
+              ORG="tazama-lf"
+            else
+              ORG="frmscoe"
+            fi
+
+            git clone https://github.com/$ORG/$repo.git
             cd $repo
-            git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/frmscoe/$repo.git
+            git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/$ORG/$repo.git
 
             if git ls-remote --heads origin sync-workflows-update | grep sync-workflows-update; then
               # Branch exists, pull the latest changes
@@ -98,42 +143,21 @@ jobs:
             fi
 
             cd ..
-            mkdir -p temp-workflows
-            cp -r .github/workflows/* temp-workflows/
-            rm temp-workflows/sync-workflows.yml  # Remove the sync-workflows.yml to avoid recursive syncing
-            rm temp-workflows/node.js.yml  # Remove the node.js.yml to avoid removing benchmarking tests specific for each repo
             mkdir -p $repo/.github/workflows  # Create the workflows directory if it does not exist
-            
-            # Copy all files except the specific ones to certain repos
-            if [[ " ${SPECIFIC_REPOS} " =~ " ${repo} " ]]; then
-              for file in temp-workflows/*; do
-                if ! [[ " ${SPECIFIC_FILES} " =~ " $(basename $file) " ]]; then
-                  cp -r $file $repo/.github/workflows/
-                fi
-              done
-            else
-              cp -r temp-workflows/* $repo/.github/workflows/
-            fi
 
-            cd $repo
-            git add .
-            git commit -m "ci: sync workflows from central-workflows ${SIGNED_OFF_BY}" || echo "No changes to commit"
-            git push origin sync-workflows-update || git push origin sync-workflows-update --force
-            
-            # Clear the GITHUB_TOKEN environment variable and use a temporary file for gh authentication
-            echo "${{ secrets.GH_TOKEN }}" > /tmp/gh_token
-            unset GITHUB_TOKEN
-            gh auth login --with-token < /tmp/gh_token
-            
-            # Create the PR with reviewers
-            IFS=',' read -ra REVIEWERS <<< "${PR_REVIEWERS}"
-            REVIEWERS_ARGS=""
-            for reviewer in "${REVIEWERS[@]}"; do
-              REVIEWERS_ARGS+="--reviewer $reviewer "
+            # Unified copy: apply per-file rules before copying
+            for file in temp-workflows/*; do
+              filename=$(basename "$file")
+              # Docker workflows: skip for repos that don't build Docker images
+              if [[ " ${SPECIFIC_REPOS} " =~ " ${repo} " ]] && [[ " ${SPECIFIC_FILES} " =~ " ${filename} " ]]; then
+                continue
+              fi
+              # publish.yml: only copy to designated library repos
+              if [[ "${filename}" == "publish.yml" ]] && ! [[ " ${PUBLISH_REPOS} " =~ " ${repo} " ]]; then
+                continue
+              fi
+              cp -r "$file" "$repo/.github/workflows/"
             done
-
-            gh pr create --title "ci: sync workflows from central-workflows" --body "This PR syncs workflows from the central-workflows repository. ${SIGNED_OFF_BY}" --base dev --head sync-workflows-update $REVIEWERS_ARGS || echo "PR already exists, updating existing PR"
-            
             # Cleanup
             rm /tmp/gh_token
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-## v1.1.0 (future date, 2024)
-
-* Next change summary here
-
-## v1.0.0 (July 2nd, 2024)
-
-* Add workflows, pr template, version and changelog.md file.

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-v1.0.0


### PR DESCRIPTION
## Summary

This PR introduces a canonical `publish.yml` for all `tazama-lf` npm library repos, and extends `sync-workflows.yml` to propagate it to the right repos.

---

## Changes

### `publish.yml` (new)

| Aspect | Previous (per-repo) | Canonical (this PR) |
|--------|--------------------|--------------------|
| Trigger | `push: dev` + `workflow_dispatch` | `workflow_dispatch` only |
| npm scope | `@frmscoe` (most repos) | `@tazama-lf` uniformly |
| Publish token | Mixed (`GH_TOKEN_LIB`, `FRMS_COE_STARTUP`, `GITHUB_TOKEN`) | `GH_TOKEN_LIB` everywhere |
| Auto-versioning | ✅ Yes (commit-message-driven `npm version`) | ❌ Dropped — developer sets version manually |
| Version-bump PR | ✅ Yes | ❌ Dropped |
| `actions/checkout` | v3 | v4 |
| `actions/setup-node` | v3 | v4 |
| `node-version` | 16.x | 20 |
| Slack notification | References auto-PR (broken without bump logic) | Simplified (repo + actor) |

**Why `workflow_dispatch` only?**  
Developers set the version in `package.json` and publish the RC package manually before creating a PR. A `push: dev` trigger would hit a version-collision error against the already-published package. The `node.js.yml` CI workflow already validates build/test/lint on every push and PR.

Automatic `latest`-tag publishing on merge to `main` (strip `-rc.X`, republish) is tracked in **#27**.

### `sync-workflows.yml` (updated)

- **8 new repos** added to `REPOS` and `SPECIFIC_REPOS` (no Docker): `auth-lib-provider-keycloak`, `rule-902`, `tcs-lib`, `relay-service-integration-{nats,rest,kafka,rabbitmq}`, `audit-lib`
- New **`PUBLISH_REPOS`** env var — the 12 library repos that receive `publish.yml`
- **Dynamic org detection**: library repos use `tazama-lf`; service repos continue to use `frmscoe` until the full migration is done (tracked in **#28**)
- **Unified copy loop** replaces the previous `if/else` split: a single `for` loop now applies both exclusion rules in one pass:
  - Skip docker workflows (`SPECIFIC_FILES`) for non-docker repos (`SPECIFIC_REPOS`)
  - Skip `publish.yml` for any repo not in `PUBLISH_REPOS`
- `temp-workflows` bundle is now created **once before the loop** (minor efficiency fix)

---

## Testing

- `actionlint` — clean (exit 0) on both `publish.yml` and `sync-workflows.yml`

---

## Related Issues

| Issue | Status |
|-------|--------|
| #23 — Node 16 / publish.yml modernisation | Partially addresses |
| #27 — Auto `latest`-tag publish on main merge | New, tracked separately |
| #28 — Migrate sync target org from frmscoe → tazama-lf for service repos | New, tracked separately |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added manual package publish workflow and improved cross-repository workflow synchronization.
* **Repository Metadata**
  * Updated CODEOWNERS to use group-based ownership.
* **Documentation**
  * Removed existing CHANGELOG and standalone VERSION file contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->