### PR TITLE
feat: implement release train and reusable rule workflows

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable workflow: builds and pushes an RC Docker image for a rule processor.
+#
+# Each rule repo calls this workflow with its own rule_number and rule_org rather
+# than maintaining a full copy of the job definition locally.
+#
+# Caller stub example (place in each rule repo's .github/workflows/package-rule-rc.yml):
+#
+#   on:
+#     push:
+#       branches: [dev]
+#     workflow_dispatch:
+#   jobs:
+#     build:
+#       uses: tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev
+#       with:
+#         rule_number: "901"
+#         rule_org: "tazama-lf"
+#       secrets: inherit
+#
+# Please do not attempt to edit this flow without the direct consent from the DevOps team.
+# This file is managed centrally.
+
+name: Rule Executer - Rule processor RC automation (reusable)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      rule_number:
+        description: 'Zero-padded rule number (e.g. "001", "901")'
+        required: true
+        type: string
+      rule_org:
+        description: 'GitHub org that owns the rule repo ("tazama-lf" or "frmscoe")'
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN_LIB:
+        required: true
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: true
+
+jobs:
+  automate-rule-executer:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout rule repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Read rule version from package.json
+        id: rule_version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "❌ Could not read version from package.json"
+            exit 1
+          fi
+          if [[ "$VERSION" != *-* ]]; then
+            echo "❌ RC package-rule-rc.yml triggered but version '$VERSION' is not a prerelease."
+            echo "   Expected a version with a prerelease suffix (e.g. 1.0.0-rc.1)."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Rule version: $VERSION"
+
+      - name: Clone Rule Executer repository (dev branch)
+        run: |
+          git clone https://github.com/tazama-lf/rule-executer -b dev rule-executer
+          echo "Rule Executer clone complete."
+
+      - name: Prepare rule-executer-${{ inputs.rule_number }}
+        run: |
+          cp -R rule-executer "rule-executer-${{ inputs.rule_number }}"
+          echo "Created rule-executer-${{ inputs.rule_number }}"
+
+      - name: Modify package.json and Dockerfile for rule ${{ inputs.rule_number }}
+        run: |
+          RULE_DIR="rule-executer-${{ inputs.rule_number }}"
+          RULE_NUM="${{ inputs.rule_number }}"
+          RULE_ORG="${{ inputs.rule_org }}"
+          VERSION="${{ steps.rule_version.outputs.VERSION }}"
+
+          echo "Applying substitutions for rule-${RULE_NUM} (org: ${RULE_ORG}, version: ${VERSION})"
+
+          # Update rule dependency in package.json:
+          #   "rule": "npm:@tazama-lf/rule-901@X.Y.Z"
+          #   → for tazama-lf: keep @tazama-lf, change rule number and version
+          #   → for frmscoe:   switch namespace to @frmscoe, change rule number and version
+          if [ "$RULE_ORG" = "frmscoe" ]; then
+            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@frmscoe/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+          else
+            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@tazama-lf/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+          fi
+
+          # Validate rule dependency rewrite succeeded — fail if pattern didn't match
+          EXPECTED_SCOPE=$( [ "$RULE_ORG" = "frmscoe" ] && echo "@frmscoe" || echo "@tazama-lf" )
+          if ! grep -q "npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}" "${RULE_DIR}/package.json"; then
+            echo "❌ Failed to update rule dependency in package.json — pattern may have changed"
+            echo "   Expected: npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}"
+            grep '"rule"' "${RULE_DIR}/package.json" || echo "   (no 'rule' key found)"
+            exit 1
+          fi
+
+          # Update RULE_NAME and APM_SERVICE_NAME in Dockerfile (flexible pattern — not hardcoded to 901)
+          sed -i "s/ENV RULE_NAME=\"[^\"]*\"/ENV RULE_NAME=\"${RULE_NUM}\"/" "${RULE_DIR}/Dockerfile"
+          sed -i "s/ENV APM_SERVICE_NAME=rule-[^ ]*/ENV APM_SERVICE_NAME=rule-${RULE_NUM}/" "${RULE_DIR}/Dockerfile"
+
+          echo "=== package.json rule dep after substitution ==="
+          grep '"rule"' "${RULE_DIR}/package.json"
+          echo "=== Dockerfile RULE_NAME after substitution ==="
+          grep 'RULE_NAME\|APM_SERVICE_NAME' "${RULE_DIR}/Dockerfile"
+
+          # Validate substitutions actually occurred — fail fast if template changed upstream
+          if ! grep -q "ENV RULE_NAME=\"${RULE_NUM}\"" "${RULE_DIR}/Dockerfile"; then
+            echo "❌ Failed to update RULE_NAME in Dockerfile — template may have changed"
+            exit 1
+          fi
+          if ! grep -q "ENV APM_SERVICE_NAME=rule-${RULE_NUM}" "${RULE_DIR}/Dockerfile"; then
+            echo "❌ Failed to update APM_SERVICE_NAME in Dockerfile — template may have changed"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: |
+          cd "rule-executer-${{ inputs.rule_number }}"
+          npm ci
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+
+      - name: Build and push RC Docker image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          VERSION="${{ steps.rule_version.outputs.VERSION }}"
+          RULE_NUM="${{ inputs.rule_number }}"
+          IMAGE="tazamaorg/rule-${RULE_NUM}"
+
+          echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+
+          # Build once, tag with versioned prerelease and moving :rc pointer
+          docker build -t "${IMAGE}:${VERSION}" -t "${IMAGE}:rc" "rule-executer-${RULE_NUM}"
+
+          docker push "${IMAGE}:${VERSION}"
+          docker push "${IMAGE}:rc"
+
+          docker rmi "${IMAGE}:${VERSION}" "${IMAGE}:rc"
+          echo "RC image pushed: ${IMAGE}:${VERSION} and ${IMAGE}:rc"
+
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST -H 'Content-type: application/json' --data '{
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "New Rule RC Docker image published :ship:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Rule:*\nrule-${{ inputs.rule_number }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Version:*\n${{ steps.rule_version.outputs.VERSION }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*DockerHub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"
+                  }
+                ]
+              }
+            ]
+          }' "$SLACK_WEBHOOK_URL" || true

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable workflow: builds and pushes a stable Docker image for a rule processor.
+#
+# Triggered on merge to main in the rule repo (stable release). Produces both a
+# versioned tag and the :latest moving pointer.
+#
+# Each rule repo calls this workflow with its own rule_number and rule_org rather
+# than maintaining a full copy of the job definition locally.
+#
+# Caller stub example (place in each rule repo's .github/workflows/package-rule.yml):
+#
+#   on:
+#     push:
+#       branches: [main]
+#     workflow_dispatch:
+#   jobs:
+#     build:
+#       uses: tazama-lf/workflows/.github/workflows/package-rule.yml@dev
+#       with:
+#         rule_number: "901"
+#         rule_org: "tazama-lf"
+#       secrets: inherit
+#
+# Please do not attempt to edit this flow without the direct consent from the DevOps team.
+# This file is managed centrally.
+
+name: Rule Executer - Rule processor stable automation (reusable)
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      rule_number:
+        description: 'Zero-padded rule number (e.g. "001", "901")'
+        required: true
+        type: string
+      rule_org:
+        description: 'GitHub org that owns the rule repo ("tazama-lf" or "frmscoe")'
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN_LIB:
+        required: true
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: true
+
+jobs:
+  automate-rule-executer:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout rule repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Read rule version from package.json
+        id: rule_version
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "❌ Could not read version from package.json"
+            exit 1
+          fi
+          if [[ "$VERSION" == *-* ]]; then
+            echo "❌ Stable package-rule.yml triggered but version '$VERSION' is a prerelease."
+            echo "   Merge to main should be blocked by version-check.yml — investigate branch protection."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Rule version: $VERSION"
+
+      - name: Clone Rule Executer repository (main branch)
+        run: |
+          git clone https://github.com/tazama-lf/rule-executer -b main rule-executer
+          echo "Rule Executer clone complete."
+
+      - name: Prepare rule-executer-${{ inputs.rule_number }}
+        run: |
+          cp -R rule-executer "rule-executer-${{ inputs.rule_number }}"
+          echo "Created rule-executer-${{ inputs.rule_number }}"
+
+      - name: Modify package.json and Dockerfile for rule ${{ inputs.rule_number }}
+        run: |
+          RULE_DIR="rule-executer-${{ inputs.rule_number }}"
+          RULE_NUM="${{ inputs.rule_number }}"
+          RULE_ORG="${{ inputs.rule_org }}"
+          VERSION="${{ steps.rule_version.outputs.VERSION }}"
+
+          echo "Applying substitutions for rule-${RULE_NUM} (org: ${RULE_ORG}, version: ${VERSION})"
+
+          # Update rule dependency in package.json
+          if [ "$RULE_ORG" = "frmscoe" ]; then
+            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@frmscoe/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+          else
+            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@tazama-lf/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+          fi
+
+          # Validate rule dependency rewrite succeeded — fail if pattern didn't match
+          EXPECTED_SCOPE=$( [ "$RULE_ORG" = "frmscoe" ] && echo "@frmscoe" || echo "@tazama-lf" )
+          if ! grep -q "npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}" "${RULE_DIR}/package.json"; then
+            echo "❌ Failed to update rule dependency in package.json — pattern may have changed"
+            echo "   Expected: npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}"
+            grep '"rule"' "${RULE_DIR}/package.json" || echo "   (no 'rule' key found)"
+            exit 1
+          fi
+
+          # Update RULE_NAME and APM_SERVICE_NAME in Dockerfile (flexible pattern — not hardcoded to 901)
+          sed -i "s/ENV RULE_NAME=\"[^\"]*\"/ENV RULE_NAME=\"${RULE_NUM}\"/" "${RULE_DIR}/Dockerfile"
+          sed -i "s/ENV APM_SERVICE_NAME=rule-[^ ]*/ENV APM_SERVICE_NAME=rule-${RULE_NUM}/" "${RULE_DIR}/Dockerfile"
+
+          echo "=== package.json rule dep after substitution ==="
+          grep '"rule"' "${RULE_DIR}/package.json"
+          echo "=== Dockerfile RULE_NAME after substitution ==="
+          grep 'RULE_NAME\|APM_SERVICE_NAME' "${RULE_DIR}/Dockerfile"
+
+          # Validate substitutions actually occurred — fail fast if template changed upstream
+          if ! grep -q "ENV RULE_NAME=\"${RULE_NUM}\"" "${RULE_DIR}/Dockerfile"; then
+            echo "❌ Failed to update RULE_NAME in Dockerfile — template may have changed"
+            exit 1
+          fi
+          if ! grep -q "ENV APM_SERVICE_NAME=rule-${RULE_NUM}" "${RULE_DIR}/Dockerfile"; then
+            echo "❌ Failed to update APM_SERVICE_NAME in Dockerfile — template may have changed"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: |
+          cd "rule-executer-${{ inputs.rule_number }}"
+          npm ci
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+
+      - name: Build and push stable Docker image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          VERSION="${{ steps.rule_version.outputs.VERSION }}"
+          RULE_NUM="${{ inputs.rule_number }}"
+          IMAGE="tazamaorg/rule-${RULE_NUM}"
+
+          echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+
+          # Build once, tag with versioned and :latest moving pointer
+          docker build -t "${IMAGE}:${VERSION}" -t "${IMAGE}:latest" "rule-executer-${RULE_NUM}"
+
+          docker push "${IMAGE}:${VERSION}"
+          docker push "${IMAGE}:latest"
+
+          docker rmi "${IMAGE}:${VERSION}" "${IMAGE}:latest"
+          echo "Stable image pushed: ${IMAGE}:${VERSION} and ${IMAGE}:latest"
+
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -s -X POST -H 'Content-type: application/json' --data '{
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "New Rule stable Docker image published :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Rule:*\nrule-${{ inputs.rule_number }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Version:*\n${{ steps.rule_version.outputs.VERSION }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*DockerHub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"
+                  }
+                ]
+              }
+            ]
+          }' "$SLACK_WEBHOOK_URL" || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,14 @@
 # This workflow publishes an npm package to the GitHub Package Registry (@tazama-lf scope).
 #
 # Versioning policy:
-#   Developers are expected to set the version in package.json manually and publish the RC
-#   package before (or when) creating a PR. This workflow_dispatch trigger is a safety net
-#   for republishing from CI without a local environment.
+#   The version in package.json is the only signal used to determine the dist-tag:
+#     - Prerelease (X.Y.Z-rc.N)  → published under the 'rc' dist-tag  (triggered manually from dev)
+#     - Stable (X.Y.Z)           → published under 'latest' dist-tag   (triggered automatically on merge to main)
 #
-# Automatic latest-tag publishing (strip -rc.X, publish on merge to main) is tracked in:
-#   https://github.com/tazama-lf/workflows/issues/27
+#   Developers set the version in package.json manually. The version-check.yml workflow
+#   enforces that no prerelease version can merge to main.
+#
+# Resolves: https://github.com/tazama-lf/workflows/issues/27
 #
 # Please do not attempt to edit this flow without the direct consent from the DevOps team.
 # This file is managed centrally.
@@ -16,6 +18,9 @@
 name: Publish npm package to GitHub Packages
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Prepares and opens a release PR from dev → main for a library package.
+#
+# Usage: trigger manually from the dev branch with the target stable version.
+#   - The version input MUST be a clean semver (e.g. "4.0.0") with no prerelease suffix.
+#   - The workflow resolves all internal rc dependencies to their stable equivalents,
+#     regenerates package-lock.json, commits via the GitHub API (producing a Verified
+#     commit that satisfies branch protection), and opens a PR → main for review.
+#   - After the PR is reviewed and merged, publish.yml fires automatically on push: main
+#     and publishes the package under the 'latest' dist-tag.
+#
+# Dependency resolution rules:
+#   Pinned rc    (e.g. "7.0.2-rc.2")       → replace with npm dist-tags.latest; fail if not stable
+#   Range with rc (e.g. "^4.0.0-rc.4")     → strip prerelease from base → "^4.0.0"; fail if latest < base
+#   Pinned stable / range stable            → leave unchanged
+#
+# Please do not attempt to edit this flow without the direct consent from the DevOps team.
+# This file is managed centrally.
+
+name: Release train
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# checkov:skip=CKV_GHA_7:Release train is operator-controlled; version input is validated and
+# only determines the release branch name / package.json version — not the build artifact source.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target stable version (e.g. 4.0.0) — must not contain a prerelease suffix'
+        required: true
+        type: string
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      VERSION_INPUT: ${{ inputs.version }}
+
+    steps:
+      - name: Validate version input
+        run: |
+          VERSION="$VERSION_INPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "❌ Version input '$VERSION' contains a prerelease suffix."
+            echo "   Provide a clean semver (e.g. 4.0.0), not a prerelease."
+            exit 1
+          fi
+          # Basic semver format check: X.Y.Z
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Version input '$VERSION' is not a valid semver (expected X.Y.Z)."
+            exit 1
+          fi
+          echo "✅ Version input '$VERSION' is valid."
+
+      - name: Checkout dev branch
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          token: ${{ secrets.GH_TOKEN_LIB }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com/'
+          scope: '@tazama-lf'
+
+      - name: Add @frmscoe registry scope
+        run: echo "@frmscoe:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+
+      - name: Resolve internal rc dependencies to stable
+        id: resolve_deps
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+        run: |
+          CHANGED=0
+          PKG=$(cat package.json)
+
+          # Process both dependencies and devDependencies
+          for DEP_FIELD in dependencies devDependencies peerDependencies; do
+            # Get all @tazama-lf and @frmscoe keys in this field
+            KEYS=$(echo "$PKG" | jq -r ".${DEP_FIELD} // {} | keys[]" | grep -E '^@(tazama-lf|frmscoe)/' || true)
+            for KEY in $KEYS; do
+              CURRENT=$(echo "$PKG" | jq -r ".${DEP_FIELD}[\"${KEY}\"]")
+              echo "Checking $KEY = $CURRENT"
+
+              # Detect pinned rc: X.Y.Z-rc.N (no leading ^ or ~)
+              if [[ "$CURRENT" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z] ]]; then
+                LATEST=$(npm view "${KEY}" dist-tags.latest 2>/dev/null || true)
+                if [ -z "$LATEST" ]; then
+                  echo "❌ Cannot resolve stable version for ${KEY} (pinned rc: ${CURRENT})"
+                  exit 1
+                fi
+                if [[ "$LATEST" == *-* ]]; then
+                  echo "❌ ${KEY}@latest is '${LATEST}' (still a prerelease). Publish stable first."
+                  exit 1
+                fi
+                echo "  → $KEY: $CURRENT → $LATEST"
+                PKG=$(echo "$PKG" | jq ".${DEP_FIELD}[\"${KEY}\"] = \"${LATEST}\"")
+                CHANGED=1
+
+              # Detect range with rc prefix: ^X.Y.Z-rc.N or ~X.Y.Z-rc.N
+              elif [[ "$CURRENT" =~ ^[\^~][0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z] ]]; then
+                RANGE_CHAR="${CURRENT:0:1}"
+                BASE="${CURRENT:1}"
+                STABLE_BASE="${BASE%%-*}"  # strip -rc.N from base
+                LATEST=$(npm view "${KEY}" dist-tags.latest 2>/dev/null || true)
+                if [ -z "$LATEST" ]; then
+                  echo "❌ Cannot resolve stable version for ${KEY} (range with rc: ${CURRENT})"
+                  exit 1
+                fi
+                if [[ "$LATEST" == *-* ]]; then
+                  echo "❌ ${KEY}@latest is '${LATEST}' (still a prerelease). Publish stable first."
+                  exit 1
+                fi
+                NEW_RANGE="${RANGE_CHAR}${STABLE_BASE}"
+                echo "  → $KEY: $CURRENT → $NEW_RANGE"
+                PKG=$(echo "$PKG" | jq ".${DEP_FIELD}[\"${KEY}\"] = \"${NEW_RANGE}\"")
+                CHANGED=1
+
+              else
+                echo "  ✅ $KEY: $CURRENT (no change needed)"
+              fi
+            done
+          done
+
+          # Write resolved package.json
+          echo "$PKG" | jq '.' > package.json
+
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "Dependency resolution complete (changed=$CHANGED)"
+
+      - name: Update version in package.json
+        run: |
+          VERSION="$VERSION_INPUT"
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          echo "Version set to $VERSION"
+
+      - name: Regenerate package-lock.json
+        run: npm install --package-lock-only
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+
+      - name: Commit and push to release branch via GitHub API
+        id: push_branch
+        env:
+          GH_API_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          BRANCH="release/v${VERSION}"
+          REPO="${{ github.repository }}"
+          API="https://api.github.com/repos/${REPO}"
+
+          # Get current dev branch SHA to base the new branch on
+          DEV_SHA=$(curl -s -H "Authorization: Bearer $GH_API_TOKEN" \
+            "${API}/git/ref/heads/dev" | jq -r '.object.sha')
+          if [ -z "$DEV_SHA" ] || [ "$DEV_SHA" = "null" ]; then
+            echo "❌ Failed to get dev branch SHA — check API permissions"
+            exit 1
+          fi
+          echo "Dev SHA: $DEV_SHA"
+
+          # Create the release branch; if it already exists force-reset to current dev HEAD
+          # so that reruns always build from the latest dev state (not a stale branch tip)
+          CREATE_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer $GH_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "${API}/git/refs" \
+            -d "{\"ref\":\"refs/heads/${BRANCH}\",\"sha\":\"${DEV_SHA}\"}")
+          if [ "$CREATE_HTTP" = "201" ]; then
+            echo "Branch $BRANCH created at $DEV_SHA"
+          else
+            echo "Branch $BRANCH already exists — force-resetting to dev HEAD ($DEV_SHA)"
+            curl -s -X PATCH -H "Authorization: Bearer $GH_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              "${API}/git/refs/heads/${BRANCH}" \
+              -d "{\"sha\":\"${DEV_SHA}\",\"force\":true}" | jq -r '.ref // .message'
+          fi
+
+          # Branch is now pinned to DEV_SHA in both cases
+          BRANCH_SHA="$DEV_SHA"
+          TREE_SHA=$(curl -s -H "Authorization: Bearer $GH_API_TOKEN" \
+            "${API}/git/commits/${BRANCH_SHA}" | jq -r '.tree.sha')
+          if [ -z "$TREE_SHA" ] || [ "$TREE_SHA" = "null" ]; then
+            echo "❌ Failed to get tree SHA for commit $BRANCH_SHA"
+            exit 1
+          fi
+
+          # Build new tree with updated files
+          NEW_TREE=$(curl -s -X POST -H "Authorization: Bearer $GH_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "${API}/git/trees" \
+            -d "{
+              \"base_tree\": \"${TREE_SHA}\",
+              \"tree\": [
+                {\"path\":\"package.json\",\"mode\":\"100644\",\"type\":\"blob\",\"content\":$(jq -Rs '.' package.json)},
+                {\"path\":\"package-lock.json\",\"mode\":\"100644\",\"type\":\"blob\",\"content\":$(jq -Rs '.' package-lock.json)}
+              ]
+            }" | jq -r '.sha')
+          if [ -z "$NEW_TREE" ] || [ "$NEW_TREE" = "null" ]; then
+            echo "❌ Failed to create new tree via GitHub API"
+            exit 1
+          fi
+          echo "New tree SHA: $NEW_TREE"
+
+          # Create commit (GitHub API produces Verified commits)
+          NEW_COMMIT=$(curl -s -X POST -H "Authorization: Bearer $GH_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "${API}/git/commits" \
+            -d "{
+              \"message\": \"chore: prepare release v${VERSION}\n\n- Set version to ${VERSION}\n- Resolve internal rc dependencies to stable\n- Regenerate package-lock.json\",
+              \"tree\": \"${NEW_TREE}\",
+              \"parents\": [\"${BRANCH_SHA}\"]
+            }" | jq -r '.sha')
+          if [ -z "$NEW_COMMIT" ] || [ "$NEW_COMMIT" = "null" ]; then
+            echo "❌ Failed to create commit via GitHub API"
+            exit 1
+          fi
+          echo "New commit SHA: $NEW_COMMIT"
+
+          # Update the branch ref to the new commit
+          curl -s -X PATCH -H "Authorization: Bearer $GH_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "${API}/git/refs/heads/${BRANCH}" \
+            -d "{\"sha\":\"${NEW_COMMIT}\"}" | jq -r '.ref // .message'
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Branch $BRANCH updated to commit $NEW_COMMIT"
+
+      - name: Open PR to main
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+        run: |
+          VERSION="$VERSION_INPUT"
+          BRANCH="${{ steps.push_branch.outputs.branch }}"
+
+          # Write PR body to temp file using printf to avoid heredoc/YAML conflicts
+          printf "## Release v%s\n\nThis PR was prepared automatically by release-train.yml.\n\n**Changes:**\n- Version bumped to %s\n- Internal rc dependencies resolved to stable\n- package-lock.json regenerated\n\n**After merging:**\n- publish.yml will fire on push to main and publish %s under the latest dist-tag.\n\nPlease review the dependency changes and version bump before approving.\n" \
+            "$VERSION" "$VERSION" "$VERSION" > /tmp/pr-body.md
+
+          if ! gh pr create \
+            --title "release: v${VERSION}" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$BRANCH" \
+            --reviewer "${{ secrets.GH_USERNAME }}"; then
+            EXISTING=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING" ]; then
+              echo "PR #${EXISTING} already exists for $BRANCH — skipping."
+            else
+              echo "❌ gh pr create failed and no existing PR was found."
+              exit 1
+            fi
+          fi

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -95,7 +95,7 @@ jobs:
             relay-service-integration-kafka
             relay-service-integration-rabbitmq
             audit-lib
-          PUBLISH_REPOS: |  # Library repos that publish npm packages — the only repos that receive publish.yml
+          PUBLISH_REPOS: |  # Library repos that publish npm packages — the only repos that receive publish.yml and version-check.yml
             frms-coe-lib
             frms-coe-startup-lib
             auth-lib
@@ -108,6 +108,9 @@ jobs:
             relay-service-integration-kafka
             relay-service-integration-rabbitmq
             audit-lib
+          RULE_REPOS: |  # Rule repos that receive caller stubs instead of full package-rule*.yml copies
+            rule-901
+            rule-902
           PR_REVIEWERS: ${{ secrets.GH_USERNAME }}  # List of reviewers
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
@@ -156,15 +159,58 @@ jobs:
               if in_list "$repo" "$SPECIFIC_REPOS" && [[ " ${SPECIFIC_FILES} " =~ " ${filename} " ]]; then
                 continue
               fi
-              # publish.yml: only copy to designated library repos
-              if [[ "${filename}" == "publish.yml" ]] && ! in_list "$repo" "$PUBLISH_REPOS"; then
+              # publish.yml, version-check.yml, and release-train.yml: only copy to designated library repos
+              if [[ "${filename}" == "publish.yml" || "${filename}" == "version-check.yml" || "${filename}" == "release-train.yml" ]] && ! in_list "$repo" "$PUBLISH_REPOS"; then
+                continue
+              fi
+              # package-rule*.yml canonical definitions: never copy to rule repos — stubs are stamped below
+              if in_list "$repo" "$RULE_REPOS" && [[ "${filename}" == package-rule*.yml ]]; then
                 continue
               fi
               cp -r "$file" "$repo/.github/workflows/"
             done
 
-            cd $repo
-            git add .
+            # Stamp caller stubs for rule repos (replaces the full per-repo copies)
+            if in_list "$repo" "$RULE_REPOS"; then
+              RULE_NUM="${repo#rule-}"  # strip "rule-" prefix → "901", "902"
+              # RC caller stub
+              printf '%s\n' \
+                '# SPDX-License-Identifier: Apache-2.0' \
+                '# This file is managed centrally — do not edit manually.' \
+                '# To change build behaviour, update the reusable workflow in tazama-lf/workflows.' \
+                'on:' \
+                '  push:' \
+                '    branches: [dev]' \
+                '  workflow_dispatch:' \
+                'jobs:' \
+                '  build:' \
+                "    uses: tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev" \
+                '    with:' \
+                "      rule_number: \"${RULE_NUM}\"" \
+                '      rule_org: "tazama-lf"' \
+                '    secrets: inherit' \
+                > "$repo/.github/workflows/package-rule-rc.yml"
+              # Stable caller stub
+              printf '%s\n' \
+                '# SPDX-License-Identifier: Apache-2.0' \
+                '# This file is managed centrally — do not edit manually.' \
+                '# To change build behaviour, update the reusable workflow in tazama-lf/workflows.' \
+                'on:' \
+                '  push:' \
+                '    branches: [main]' \
+                '  workflow_dispatch:' \
+                'jobs:' \
+                '  build:' \
+                "    uses: tazama-lf/workflows/.github/workflows/package-rule.yml@main" \
+                '    with:' \
+                "      rule_number: \"${RULE_NUM}\"" \
+                '      rule_org: "tazama-lf"' \
+                '    secrets: inherit' \
+                > "$repo/.github/workflows/package-rule.yml"
+              echo "Stamped caller stubs for rule-${RULE_NUM} (tazama-lf)"
+            fi
+            cd "$repo"
+            git add .github/workflows/
             git commit -m "ci: sync workflows from central-workflows ${SIGNED_OFF_BY}" || echo "No changes to commit"
             git push origin sync-workflows-update || git push origin sync-workflows-update --force
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Blocks a PR from merging to main if package.json contains a prerelease
+# version suffix (e.g. -rc.1). The developer must strip the suffix manually
+# in the release PR before this check will pass.
+#
+# This is the companion guard for the push: main trigger in publish.yml —
+# it ensures that only clean semver versions (X.Y.Z) ever reach main and
+# are published as the 'latest' dist-tag.
+#
+# Please do not attempt to edit this flow without the direct consent from the DevOps team.
+# This file is managed centrally.
+
+name: Version check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Reject prerelease version on main PR
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if [[ "$VERSION" == *-* ]]; then
+            echo "❌ package.json version '$VERSION' contains a prerelease suffix."
+            echo "   Strip the suffix (e.g. change '$VERSION' → '${VERSION%-*}') before merging to main."
+            exit 1
+          fi
+          echo "✅ Version '$VERSION' is a clean release version — OK to merge."


### PR DESCRIPTION
## Summary

Implements the full release pipeline described in #30.

### Changes

| File | Type | Notes |
|---|---|---|
| `version-check.yml` | New | Gates PRs to `main`; fails if `package.json` version contains `-` |
| `publish.yml` | Updated | Added `push: branches: [main]` trigger  resolves #27 |
| `package-rule-rc.yml` | New | Reusable `workflow_call` for RC Docker builds |
| `package-rule.yml` | New | Reusable `workflow_call` for stable Docker builds |
| `release-train.yml` | New | `workflow_dispatch` on `dev`; resolves rc deps, bumps version, Verified API commit, opens PR |
| `sync-workflows.yml` | Updated | `RULE_REPOS` env var; `printf`-based stub-stamping; copy-loop filters |

### Security improvements (over old per-repo copies)
- No `cat .npmrc` token exposure
- No job-level `GITHUB_TOKEN` shadowing
- Explicit `NODE_AUTH_TOKEN` per step only
- Version read from checked-out `package.json` (no GitHub API call with `?ref=` race)
- `npm ci` (not `npm install` with lock deletion)

### Validation
All 6 files pass `actionlint` with zero warnings.

Closes #27. Addresses #30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable pipelines to build, tag, and publish per-rule container images for RC and stable releases
  * Release-train workflow to create release branches and prepare stable releases
  * Version-check workflow that blocks PRs containing prerelease versions

* **Chores**
  * Centralized workflow sync with repo-specific workflow stubs for rule repos
  * Publish workflow trigger and release-tagging policy clarified and updated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->