### PR TITLE
feat: add scorecard and branch-target-check workflows

### DIFF
--- a/.github/workflows/branch-target-check.yml
+++ b/.github/workflows/branch-target-check.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Enforces the feature-branch → dev → main development workflow.
+#
+# When `main` is the default branch, GitHub pre-selects it as the PR base in the
+# UI and in `gh pr create`. This check fails immediately with a clear, actionable
+# message if a PR targets main from any branch other than `dev` or `release/v<N>.*`,
+# saving developers from a confusing "branch is locked" error or a misleading
+# "prerelease version detected" message from version-check.yml.
+#
+# Allowed sources for PRs to main:
+#   dev          — the normal integration branch
+#   release/v<N>.* — release-train branches created by release-train.yml (must start with a digit)
+#
+# Please do not attempt to edit this flow without the direct consent from the DevOps team.
+# This file is managed centrally.
+
+name: Branch target check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source branch is dev or release/v<N>.*
+        env:
+          SOURCE: ${{ github.head_ref }}
+        run: |
+          if [[ "$SOURCE" == "dev" || "$SOURCE" == release/v[0-9]* ]]; then
+            echo "✅ Source branch '$SOURCE' is a valid base for a PR to main."
+          else
+            echo "❌ PRs to main must come from 'dev' or a 'release/v<N>.*' branch (e.g. release/v1.2)."
+            echo "   This PR is from '$SOURCE'."
+            echo ""
+            echo "   If you are working on a feature or fix, please retarget this PR to 'dev':"
+            echo "     gh pr edit --base dev"
+            echo ""
+            echo "   Only 'dev' → main (via release-train.yml) and 'release/v<N>.*' → main merges are permitted."
+            exit 1
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '15 16 * * 0'
+  push:
+    branches:
+      - main
+      - dev
+
+# Scorecard workflow restrictions (enforced when publish_results=true):
+#   - No workflow-level env vars or defaults
+#   - No workflow-level write permissions (read-all is fine)
+#   - Only the scorecard job may use id-token: write
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for uploading SARIF results to the code-scanning dashboard
+      security-events: write
+      # Required for GitHub OIDC token used by publish_results
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results (badge + REST API) only when running on the default
+          # branch or on a schedule/branch-protection event.  Dev-branch runs
+          # still score the repo but do not overwrite the published badge.
+          publish_results: ${{ github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'branch_protection_rule' }}
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -167,6 +167,10 @@ jobs:
               if in_list "$repo" "$RULE_REPOS" && [[ "${filename}" == package-rule*.yml ]]; then
                 continue
               fi
+              # scorecard.yml: only copy to service repos â€" skip library/npm repos and rule repos
+              if [[ "${filename}" == "scorecard.yml" ]] && in_list "$repo" "$PUBLISH_REPOS"; then
+                continue
+              fi
               cp -r "$file" "$repo/.github/workflows/"
             done
 


### PR DESCRIPTION
## Summary

Adds two new canonical workflows and updates `sync-workflows.yml` scoping to distribute them correctly.

---

### `scorecard.yml` — OSSF Scorecard supply-chain security

Replaces the stale, per-repo `scorecard.yml` (currently present in service repos with outdated action SHAs and no conditional `publish_results`) with a centrally-managed canonical version.

**Key changes from the existing per-repo version:**

| Item | Before | After |
|---|---|---|
| `push` trigger | `dev` only | `main` **and** `dev` |
| `publish_results` | hardcoded `true` | `true` on `main`/`schedule`/`branch_protection_rule`; `false` on `dev` |
| `actions/checkout` | v4.1.1 (`b4ffde65`) | **v6.0.2** (`de0fac2e`) |
| `ossf/scorecard-action` | v2.3.1 (`0864cf19`) | **v2.4.3** (`4eaacf05`) |
| `actions/upload-artifact` | v3.pre.node20 (`97a0fba1`) | **v7.0.0** (`bbbca2dd`) |
| `github/codeql-action/upload-sarif` | v3.24.9 (`1b1aada4`) | **v4.34.1** (`38697555`) |

**`publish_results` design:**
```yaml
publish_results: ${{ github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'branch_protection_rule' }}
```
Results are only published to the OSSF badge/API when running on `main` (the authoritative production state). Dev-branch runs still score the repo locally and upload SARIF to code-scanning — without updating the public badge.

**Sync scoping:** `scorecard.yml` is skipped for `PUBLISH_REPOS` (library/npm packages + rule repos). Only service repos receive it.

> **Note:** The `push: [main]` trigger and `publish_results: true` on `main` are forward-looking — they become meaningful once `main` is set as the default branch per [tazama-lf/technical-steering-committee#14](https://github.com/tazama-lf/technical-steering-committee/issues/14).

---

### `branch-target-check.yml` — PR base-branch guard

Enforces the `feature → dev → main` flow when `main` is the default branch. GitHub pre-fills `main` as the PR base in the UI and `gh pr create`; this check catches accidental mis-targets immediately.

**Logic:**
- Triggers on `pull_request: branches: [main]`
- Passes if source branch is `dev` or matches `release/v*`
- Fails with an actionable message including `gh pr edit --base dev`

**Sync scoping:** Copies to **all** repos (no exclusion).

**Security note:** `github.head_ref` is passed via an environment variable (not interpolated directly into the shell script) to prevent script injection — actionlint-verified.

---

### `sync-workflows.yml` — scoping update

Added one exclusion rule in the per-file copy loop:

```bash
# scorecard.yml: only copy to service repos — skip library/npm repos and rule repos
if [[ "${filename}" == "scorecard.yml" ]] && in_list "$repo" "$PUBLISH_REPOS"; then
  continue
fi
```

`PUBLISH_REPOS` already covers all `RULE_REPOS`, so one condition is sufficient.

---

## Checklist

- [x] actionlint passes on all three files (zero warnings)
- [x] SHAs match the official OSSF Scorecard example workflow
- [x] `github.head_ref` injection risk fixed (env var indirection)
- [x] Sync scoping tested against PUBLISH_REPOS / RULE_REPOS lists
- [x] TSC#14 approved and default branch switched to `main` (prerequisite for `publish_results: true` on `main` to take effect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added PR branch validation to enforce PRs target dev or release branches; invalid targets will fail checks and prompt retargeting.
  * Added automated supply‑chain security scanning with scheduled and push-based runs; results are uploaded and published for main.
  * Adjusted workflow synchronization to skip the security scan in specified repositories during workflow propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->