### PR TITLE
fix: dynamic Docker tag, remove Node 16, workflow docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,294 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-# workflows
-This repository is used for github workflows that will kick off Actions to be built before a PR can be pushed to the main branch.
+# tazama-lf/workflows
 
-## Workflow Documentation
+Canonical GitHub Actions workflows for the Tazama project. This repository is the **single source of truth** for CI/CD automation across all active Tazama repositories in both the `tazama-lf` and `frmscoe` organisations.
 
-All worklows are documented in this repository ynder this [path](https://github.com/tazama-lf/workflows/tree/dev/workflow-docs). The docs include details about the workflows, what they do and what triggers them to run.
+Workflow files are distributed to target repositories automatically by [`sync-workflows.yml`](.github/workflows/sync-workflows.yml) on every pull request to `dev` in this repo. The `frmscoe/workflows` repo is a manually-maintained mirror of the relevant subset of files for `frmscoe` rule repos, seeded from this repo.
+
+For detailed documentation on any individual workflow, see the [`workflow-docs/`](workflow-docs/) directory. A template for new entries is at [`workflow-docs/docs-template.md`](workflow-docs/docs-template.md).
+
+---
+
+## Repository Classes
+
+Each repository in the Tazama ecosystem belongs to one class. The class determines which workflows it receives, which SDLC path applies, and whether it builds Docker images, publishes npm packages, or both.
+
+| Class | Repos | Output | Notes |
+|-------|-------|--------|-------|
+| **Service repos** | `auth-service`, `typology-processor`, `event-director`, `event-flow`, `event-sidecar`, `lumberjack`, `nats-utilities`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor` | Docker image | Publish to Docker Hub; receive full workflow set including Docker build workflows |
+| **Other service repos** | `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` | — | In `SPECIFIC_REPOS`; do not receive `dockerhub-image-build*.yml` |
+| **Library repos** | `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `tcs-lib`, `audit-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq` | npm package | Publish to GitHub Packages under `@tazama-lf` scope |
+| **Rule repos — tazama-lf** | `rule-901`, `rule-902` | Docker image + npm package | Also in `PUBLISH_REPOS`; use `package-rule*.yml` caller stubs for Docker builds |
+| **Rule repos — frmscoe** | `rule-001` through `rule-091` (33 active repos) | Docker image | Managed via [`frmscoe/workflows`](https://github.com/frmscoe/workflows); receive Docker builds via `package-rule*.yml` caller stubs |
+| **Workflow repos** | `tazama-lf/workflows` (this repo), `frmscoe/workflows` | — | Canonical; not synced to |
+
+---
+
+## Standard PR Check Suite
+
+The following checks run automatically on every pull request across all repo classes. They are defined once here and referenced throughout the SDLC sections below.
+
+| Workflow | What it checks |
+|----------|---------------|
+| `branch-target-check.yml` | PR base branch must be `dev` (or `main` for `release/v*` branches) |
+| `conventional-commits.yml` | Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification |
+| `dco-check.yml` | All commits carry a DCO `Signed-off-by` trailer — ⚠️ [known issue #37](https://github.com/tazama-lf/workflows/issues/37) |
+| `gpg-verify.yml` | All commits are GPG-signed |
+| `codacy.yml` | Static analysis via Codacy CLI — ⚠️ [known issue #38](https://github.com/tazama-lf/workflows/issues/38) |
+| `codeql.yml` | GitHub CodeQL SAST security scan |
+| `njsscan.yml` | Node.js-specific security scan (semgrep rules) |
+| `dependency-review.yml` | Flags new dependencies with known CVEs or licence restrictions |
+| `node.js.yml` | Build, lint, and test on Node 20 — **not synced; each repo maintains its own copy** |
+
+> Pre-commit tooling (local linting, formatting, commit-msg hooks) is developer-local and not managed here. See the project [contribution guide](https://github.com/tazama-lf/tazama-documentation) for local setup guidance.
+
+---
+
+## SDLC Flows
+
+### 1. Library repos (PUBLISH_REPOS)
+
+Library repos publish versioned npm packages under the `@tazama-lf` scope. They do not produce Docker images. The versioning cycle uses rc pre-releases on `dev` and promotes to a stable release on `main`.
+
+#### Feature development → dev
+
+1. **Developer** — develops changes on a feature branch.
+2. **Developer — MANUAL** — bumps `version` in `package.json` to `X.Y.Z-rc.N`.
+3. **Developer** — opens pull request targeting `dev`.
+4. **AUTO** — [standard PR check suite](#standard-pr-check-suite) fires.
+5. **Reviewer — MANUAL** — reviews, approves, merges PR to `dev`.
+6. **AUTO** — `publish.yml` fires on `push: dev`; detects the `-rc` suffix; publishes the package to GitHub Packages under the `rc` dist-tag.
+
+#### Release → main
+
+1. **Developer — MANUAL** — triggers `release-train.yml` via `workflow_dispatch` from `dev`; enters the target stable version (e.g. `4.0.0`, no prerelease suffix).
+2. **AUTO** — `release-train.yml` resolves all `-rc.*` dependencies to their stable equivalents, regenerates `package-lock.json`, and opens a `release/vX.Y.Z → main` PR. Fails if any dependency has no stable release yet.
+3. **Developer — MANUAL** — in the release PR branch, strips the `-rc.N` suffix from `version` in `package.json`.
+4. **AUTO** — `version-check.yml` fires on the PR targeting `main`; blocks merge if the version still contains a prerelease suffix.
+5. **AUTO** — full standard PR check suite also fires on the `main`-targeting PR.
+6. **Reviewer — MANUAL** — reviews and merges the release PR to `main`.
+7. **AUTO** — `publish.yml` fires on `push: main`; detects a clean semver; publishes the package under the `latest` dist-tag.
+
+---
+
+### 2. Service repos (Docker-building)
+
+Service repos produce versioned Docker images. They do not publish npm packages.
+
+#### Feature development → dev
+
+1. **Developer — MANUAL** — updates library dependency versions in `package.json` to consume any new rc or stable library releases (this step follows the [library release cycle](#1-library-repos-publish_repos) upstream).
+2. **Developer** — develops changes on a feature branch.
+3. **Developer** — opens pull request targeting `dev`.
+4. **AUTO** — [standard PR check suite](#standard-pr-check-suite) fires, plus `dockerfile-linter.yml` if a `Dockerfile` was modified.
+5. **Reviewer — MANUAL** — reviews, approves, merges PR to `dev`.
+6. **AUTO** — `dockerhub-image-build-rc.yml` fires on `push: dev`; builds and pushes the Docker image tagged `:rc` to Docker Hub.
+7. **AUTO** — `scorecard.yml` fires on `push: dev`; runs OSSF supply-chain checks (results published to the Security tab only on `main`, schedule, and `branch_protection_rule` triggers).
+
+#### Release → main
+
+1. **Developer** — opens pull request `dev → main`.
+2. **AUTO** — standard PR check suite fires.
+3. **Reviewer — MANUAL** — reviews, approves, merges to `main`.
+4. **AUTO** — `dockerhub-image-build.yml` fires on `push: main`; reads `version` from `package.json`; builds and pushes the Docker image tagged `:X.Y.Z` to Docker Hub.
+5. **AUTO** — `sbom.yml` fires on `push: main`; generates a Software Bill of Materials from the Docker image — ⚠️ [known issue #39](https://github.com/tazama-lf/workflows/issues/39).
+6. **Release manager — MANUAL** — triggers `milestone.yml` via `workflow_dispatch` in the service repo, supplying the milestone ID.
+7. **AUTO** — `milestone.yml` closes the milestone and fires `release.yml` via `repository_dispatch`.
+8. **AUTO** — `release.yml` determines the version bump from commit messages, generates a changelog from merged PRs, creates the GitHub release, and commits updates to `CHANGELOG.md` and `VERSION` — ⚠️ [known issue #40](https://github.com/tazama-lf/workflows/issues/40).
+
+---
+
+### 3. Other service repos (no Docker CI build)
+
+`relay-service`, `batch-ppa`, `rule-executer`, and `Full-Stack-Docker-Tazama` follow the same feature development and PR check flow as Docker-building service repos but do **not** receive `dockerhub-image-build*.yml` or `sbom.yml`. Their build and release processes (if any) are managed outside this workflow set.
+
+---
+
+### 4. Rule repos — tazama-lf (rule-901, rule-902)
+
+tazama-lf rule repos are both library repos **and** Docker image producers. They follow the full library release cycle for npm publishing (including `release-train.yml`, `publish.yml`, and `version-check.yml`) and additionally build Docker images via the `package-rule*.yml` reusable workflows.
+
+1. **Merged to `dev`** — same as library repos: `publish.yml` fires and publishes the rc npm package.
+2. **AUTO** — `package-rule-rc.yml` caller stub fires on `push: dev`; calls the reusable workflow at `tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev`; builds and pushes the Docker image tagged `:rc`.
+3. **Release to `main`** — same as library repos: `release-train.yml` resolves deps, opens release PR, `version-check.yml` guards the merge.
+4. **Merged to `main`** — `publish.yml` fires and publishes the stable npm package.
+5. **AUTO** — `package-rule.yml` caller stub fires on `push: main`; calls the reusable workflow; builds and pushes Docker images tagged `:X.Y.Z` and `:latest`.
+
+---
+
+### 5. Rule repos — frmscoe (rule-001 through rule-091)
+
+frmscoe rule repos reside in the `frmscoe` organisation and are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which is a manually-maintained mirror of the relevant subset of workflows from this repo. frmscoe rule repos build Docker images via `package-rule*.yml` caller stubs (referencing `frmscoe/workflows` as the reusable workflow source) but do not use `dockerhub-image-build*.yml` or `dockerfile-linter.yml`.
+
+**Workflows frmscoe rule repos receive:** `branch-target-check.yml`, `codacy.yml`, `codeql.yml`, `conventional-commits.yml`, `dco-check.yml`, `dependency-review.yml`, `gpg-verify.yml`, `milestone.yml`, `njsscan.yml`, `node.js.yml`, `package-rule-rc.yml` (caller stub), `package-rule.yml` (caller stub), `publish.yml`, `release-train.yml`, `release.yml`, `sbom.yml`, `scorecard.yml`, `version-check.yml`.
+
+**Not received:** `dockerfile-linter.yml`, `dockerhub-image-build.yml`, `dockerhub-image-build-rc.yml`.
+
+**Sync trigger in frmscoe/workflows:** `push: dev` (not `pull_request` — sync fires after merge, not on PR open).
+
+#### SDLC
+
+1. **Developer** — develops changes on a feature branch.
+2. **Developer** — opens pull request targeting `dev`.
+3. **AUTO** — [standard PR check suite](#standard-pr-check-suite) fires.
+4. **Reviewer — MANUAL** — reviews, approves, merges to `dev`.
+5. **AUTO** — `package-rule-rc.yml` caller stub fires on `push: dev`; builds and pushes the rule Docker image tagged `:rc`.
+6. **Developer** — opens pull request `dev → main` for the release.
+7. **AUTO** — standard PR check suite fires.
+8. **Reviewer — MANUAL** — reviews, approves, merges to `main`.
+9. **AUTO** — `package-rule.yml` caller stub fires on `push: main`; builds and pushes Docker images tagged `:X.Y.Z` and `:latest`.
+
+---
+
+### 6. Canonical workflow changes (this repo)
+
+Changes to this repo propagate to all 26 target repositories. This is the highest-impact SDLC path.
+
+1. **DevOps** — modifies workflow files in `.github/workflows/`; updates the corresponding `workflow-docs/` entry.
+2. **DevOps** — opens pull request targeting `dev`.
+3. **AUTO** — standard PR check suite fires against this repo.
+4. **AUTO** — `sync-workflows.yml` fires; opens `sync-workflows-update` PRs in all 26 target repos — ⚠️ [known issue #36](https://github.com/tazama-lf/workflows/issues/36): fires on PR open, not only on merge. **Do not merge sync PRs in target repos until the source PR here is confirmed merged.**
+5. **Reviewer — MANUAL** — reviews and merges the source PR to `dev` in this repo.
+6. **Reviewers in target repos — MANUAL** — merge `sync-workflows-update` PRs in each target repo.
+7. **DevOps — MANUAL** — applies the same changes to [`frmscoe/workflows`](https://github.com/frmscoe/workflows) via a separate PR (no automated mirror exists between the two workflow repos).
+8. **AUTO** — once merged to `dev` in `frmscoe/workflows`, its `sync-workflows.yml` fires on `push: dev` and distributes the changes to all 33 frmscoe rule repos.
+
+---
+
+## Canonical Workflow Reference
+
+Triggers shown are in the context of the **target repo** where each workflow is installed and runs.
+
+| Workflow file | Purpose | Trigger (in target repo) | Synced to |
+|--------------|---------|--------------------------|-----------|
+| `branch-target-check.yml` | Enforce `dev` (or `main` for `release/v*`) as PR target | `pull_request` | All repos |
+| `codacy.yml` | Codacy static analysis | `push`, `pull_request` | All repos |
+| `codeql.yml` | GitHub CodeQL SAST | `push: [dev,main]`, `pull_request: [dev,main]`, schedule | All repos |
+| `conventional-commits.yml` | Validate Conventional Commits spec | `pull_request` | All repos |
+| `dco-check.yml` | Verify DCO Signed-off-by on commits | `pull_request` | All repos |
+| `dependency-review.yml` | Flag CVEs and licence issues in new deps | `pull_request` | All repos |
+| `dockerfile-linter.yml` | Hadolint lint of Dockerfiles | `pull_request` | All repos (no-op where no `Dockerfile` exists) |
+| `dockerhub-image-build-rc.yml` | Build and push `:rc` Docker image | `push: [dev]` | Service repos only (not SPECIFIC_REPOS) |
+| `dockerhub-image-build.yml` | Build and push versioned Docker image | `push: [main]` | Service repos only (not SPECIFIC_REPOS) |
+| `gpg-verify.yml` | Verify GPG signature on commits | `pull_request` | All repos |
+| `milestone.yml` | Close a milestone and trigger `release.yml` | `workflow_dispatch` | All repos |
+| `njsscan.yml` | Node.js security scan (semgrep) | `push`, `pull_request` | All repos |
+| `node.js.yml` | Node 20 CI: build, lint, test | `push: [dev,main]`, `pull_request: [dev,main]` | **Not synced** — each repo maintains its own copy |
+| `package-rule-rc.yml` | Reusable: build and push `:rc` Docker image for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
+| `package-rule.yml` | Reusable: build and push `:latest`/`:X.Y.Z` Docker images for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
+| `publish.yml` | Publish npm package to GitHub Packages | `push: [main]`, `workflow_dispatch` | `PUBLISH_REPOS` only |
+| `release-train.yml` | Resolve rc deps, prepare release PR, bump version | `workflow_dispatch` | `PUBLISH_REPOS` only |
+| `release.yml` | Create GitHub release, update `CHANGELOG.md` and `VERSION` | `repository_dispatch: [release]` (from `milestone.yml`) | All repos |
+| `sbom.yml` | Generate SBOM from Docker image | `push: [main]` | All repos — ⚠️ [known issue #39](https://github.com/tazama-lf/workflows/issues/39) |
+| `scorecard.yml` | OSSF Scorecard supply-chain security | `push: [main,dev]`, schedule (weekly), `branch_protection_rule` | Service repos only (not `PUBLISH_REPOS`) |
+| `sync-workflows.yml` | Distribute canonical workflows to all target repos | `pull_request: [dev]`, `workflow_dispatch` | **Not synced** — canonical-only |
+| `version-check.yml` | Block PR to `main` if `package.json` version has a prerelease suffix | `pull_request: [main]` | `PUBLISH_REPOS` only |
+
+---
+
+## Sync Distribution
+
+`sync-workflows.yml` uses four groups to control which workflows each target repo receives.
+
+| Group | Members | Behaviour |
+|-------|---------|-----------|
+| `REPOS` | All 26 tazama-lf target repos | Receive all workflows except those explicitly excluded |
+| `SPECIFIC_REPOS` | All library repos + `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` | Skip `dockerhub-image-build.yml` and `dockerhub-image-build-rc.yml` |
+| `PUBLISH_REPOS` | All library repos + `rule-901`, `rule-902` | Additionally receive `publish.yml`, `version-check.yml`, `release-train.yml`; skip `scorecard.yml` |
+| `RULE_REPOS` | `rule-901`, `rule-902` | Receive caller stubs for `package-rule*.yml` instead of the full reusable workflow definition |
+
+**Always excluded from the sync bundle:**
+
+| File | Reason |
+|------|--------|
+| `sync-workflows.yml` | Canonical-only; never distributed to target repos |
+| `node.js.yml` | Each repo maintains its own copy to allow per-repo customisation |
+
+**Full `REPOS` list (26 repos):** `relay-service`, `auth-service`, `typology-processor`, `event-director`, `event-sidecar`, `lumberjack`, `nats-utilities`, `batch-ppa`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `Full-Stack-Docker-Tazama`, `rule-executer`, `event-flow`, `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `rule-901`, `rule-902`, `tcs-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq`, `audit-lib`.
+
+> **frmscoe rule repos are not in this list.** They are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which syncs to 33 rule repos (`rule-001` through `rule-091`, active subset) via its own `sync-workflows.yml` triggered on `push: dev`.
+
+---
+
+## Routine Maintenance
+
+### Pinned action SHA updates
+
+Most workflow files pin external actions to commit SHAs for supply-chain security. Rotate these quarterly or when a Dependabot alert is raised.
+
+1. Find the new SHA on the action's GitHub releases page.
+2. Update the SHA in the canonical file in `.github/workflows/`.
+3. Update the SHA in the corresponding `workflow-docs/<file>.md` Dependencies table.
+4. Open a PR to `dev`; sync will propagate the change to all target repos on merge.
+
+### Node.js version updates
+
+`node.js.yml` is not synced and must be updated in each repo individually.
+
+1. Update the canonical `.github/workflows/node.js.yml` in this repo.
+2. Apply the same change to each repo in `REPOS`, to `frmscoe/workflows`, and its 33 target repos.
+3. Track progress in [`update-workflows.md`](-Claude-docs/update-workflows.md) (private planning doc).
+
+### gh CLI version
+
+The `gh` CLI in `sync-workflows.yml` is pinned to a hardcoded tarball URL. To update:
+
+1. Find the new release tarball URL at <https://github.com/cli/cli/releases>.
+2. Update the `curl` URL and the `tar`/`cp` filenames in the `Install GitHub CLI` step.
+
+### Publishing an rc package manually
+
+To publish a library rc without waiting for a push event:
+
+1. Go to **Actions → Publish npm package** in the target library repo.
+2. Click **Run workflow** from the `dev` branch.
+
+### Running release-train
+
+1. Go to **Actions → Release train** in the target library repo.
+2. Click **Run workflow** from the `dev` branch; supply the target stable version (e.g. `4.0.0`, no prerelease suffix).
+3. After the workflow opens the release PR, strip the `-rc.N` suffix from `version` in `package.json` before requesting merge.
+
+### Creating a release (service repos)
+
+1. Merge all changes to `main`.
+2. Go to **Actions → Milestone Workflow** in the service repo.
+3. Click **Run workflow** and enter the milestone ID.
+4. `milestone.yml` closes the milestone and fires `release.yml` via `repository_dispatch`, which creates the GitHub release and updates `CHANGELOG.md` and `VERSION`.
+
+### OSSF Scorecard
+
+`scorecard.yml` runs automatically on `push` and on a weekly schedule. To trigger it manually:
+
+1. Go to **Actions → Scorecard supply-chain security** in the target service repo.
+2. Click **Run workflow**.
+
+Results appear in **Security → Code scanning** only when triggered from `main`, a schedule, or a `branch_protection_rule` event.
+
+### Auditing sync coverage
+
+To verify all target repos reflect the latest canonical workflows:
+
+1. Go to **Actions → Sync Workflows** in this repo.
+2. Click **Run workflow** (`workflow_dispatch`) from `dev`.
+3. Review the `sync-workflows-update` PRs opened in each target repo.
+
+### Updating frmscoe/workflows
+
+There is no automated mirror between this repo and `frmscoe/workflows`. After merging workflow changes to `dev` here, open a corresponding PR in [`frmscoe/workflows`](https://github.com/frmscoe/workflows) with the same changes, referencing the source PR.
+
+---
+
+## Known Issues
+
+Active bugs where workflow behaviour differs from expectation. See the [issues tab](https://github.com/tazama-lf/workflows/issues) for the full list and status.
+
+| Issue | Affected workflow(s) | Reference |
+|-------|---------------------|-----------|
+| `sync-workflows.yml` fires on all PR events to `dev`, not only on merge — do not merge sync PRs in target repos until the source PR here is confirmed merged | `sync-workflows.yml` | [#36](https://github.com/tazama-lf/workflows/issues/36) |
+| `dco-check.yml` uses a reversed `git log` range — DCO sign-off is not being verified on the actual PR commits | `dco-check.yml` | [#37](https://github.com/tazama-lf/workflows/issues/37) |
+| Codacy CLI crashes with `MalformedInputException` on checkov output from multi-line YAML files — workaround: add `.checkov.yaml` with `skip-framework: github_actions` at the repo root | `codacy.yml` | [#38](https://github.com/tazama-lf/workflows/issues/38) |
+| `sbom.yml` is synced to library and rule repos but runs `docker build`, which fails in repos without a `Dockerfile` | `sbom.yml` | [#39](https://github.com/tazama-lf/workflows/issues/39) |
+| `milestone.yml` and `release.yml` use the deprecated `::set-output` syntax and `actions/checkout@v2` | `milestone.yml`, `release.yml` | [#40](https://github.com/tazama-lf/workflows/issues/40) |
+| Service repo clone URLs in `sync-workflows.yml` still use the `frmscoe` org — full migration to `tazama-lf` is pending | `sync-workflows.yml` | [#28](https://github.com/tazama-lf/workflows/issues/28) |

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Each repository in the Tazama ecosystem belongs to one class. The class determin
 
 ## Standard PR Check Suite
 
-The following checks run automatically on every pull request across all repo classes. They are defined once here and referenced throughout the SDLC sections below.
+The following checks run automatically on pull requests across all repo classes. They are defined once here and referenced throughout the SDLC sections below.
 
 | Workflow | What it checks |
 |----------|---------------|
-| `branch-target-check.yml` | PR base branch must be `dev` (or `main` for `release/v*` branches) |
-| `conventional-commits.yml` | Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification |
+| `branch-target-check.yml` | PR base branch must be `dev` or `release/v*` when targeting `main` — **fires on PRs to `main` only** |
+| `conventional-commits.yml` | PR title is validated against the [Conventional Commits](https://www.conventionalcommits.org/) specification |
 | `dco-check.yml` | All commits carry a DCO `Signed-off-by` trailer — ⚠️ [known issue #37](https://github.com/tazama-lf/workflows/issues/37) |
 | `gpg-verify.yml` | All commits are GPG-signed |
 | `codacy.yml` | Static analysis via Codacy CLI — ⚠️ [known issue #38](https://github.com/tazama-lf/workflows/issues/38) |
@@ -228,7 +228,7 @@ Most workflow files pin external actions to commit SHAs for supply-chain securit
 
 1. Update the canonical `.github/workflows/node.js.yml` in this repo.
 2. Apply the same change to each repo in `REPOS`, to `frmscoe/workflows`, and its 33 target repos.
-3. Track progress in [`update-workflows.md`](-Claude-docs/update-workflows.md) (private planning doc).
+3. Track progress in `update-workflows.md` (private planning doc, not committed to this repo).
 
 ### gh CLI version
 

--- a/workflow-docs/branch-target-check.md
+++ b/workflow-docs/branch-target-check.md
@@ -1,0 +1,70 @@
+# `branch-target-check.yml`
+
+## Purpose
+
+Enforces the feature-branch → dev → main development workflow by failing any PR to `main` that does not originate from `dev` or a `release/v<N>.*` branch, saving developers from confusing branch-protection errors.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | branches: `[main]` |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~15 s |
+| Concurrency | none |
+| Permissions | `contents: read` |
+
+---
+
+## Jobs
+
+### `check-source-branch` — verify PR source branch
+
+**Steps:**
+
+1. `Verify PR source branch is dev or release/v<N>.*` — shell check; exits `1` with actionable message (including `gh pr edit --base dev` hint) if source branch is not `dev` or `release/v[0-9]*`
+
+---
+
+## Required Secrets
+
+None.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+None — single run step only.
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` and `dependabot-preview[bot]` actors are excluded from the check.
+- Only guards `main` as target; no equivalent check for PRs to `dev` (any source branch is permitted).
+- Source branch value is passed via `env:` rather than inline `${{ github.head_ref }}` to prevent header injection.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/codacy.md
+++ b/workflow-docs/codacy.md
@@ -1,33 +1,78 @@
-## Workflow Name: Codacy Security Scan
+# `codacy.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow performs security scans on the codebase using Codacy and uploads the results in SARIF format to GitHub.
+Performs a Codacy security scan of the codebase and uploads results in SARIF format to GitHub Advanced Security (code scanning dashboard).
 
-#### Trigger Events:
+---
 
-`Push`: Runs on pushes to the dev and main branches.
+## Trigger
 
-`Pull Requests`: Runs on pull requests targeting dev and main.
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[dev, main]` |
+| `pull_request` | branches: `[dev, main]` |
+| `schedule` | `17 0 * * 4` (Thursday 00:17 UTC) |
 
-`Scheduled`: Runs every Thursday at 00:17 UTC.
+---
 
-#### Permissions:
+## Execution Context
 
-`contents: read`: Allows reading repository contents.
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~2–3 min |
+| Concurrency | none |
+| Permissions | `contents: read`, `security-events: write`, `actions: read` |
 
-`security-events`: write: Allows uploading SARIF results.
+---
 
-`actions: read`: Required for private repositories to retrieve Action run status.
+## Jobs
 
-- Runs on: ubuntu-latest
+### `codacy-security-scan` — Codacy Security Scan
 
-#### Workflow Steps:
+**Steps:**
 
-- Checkout Code: Uses actions/checkout@v4 to clone the repository.
-  
-- Run Codacy Analysis CLI: Executes Codacy's CLI to scan the codebase, generating a SARIF file.
-  
-- Upload SARIF Results: Uploads the SARIF file to GitHub using github/codeql-action/upload-sarif@v3.
-  
-- This workflow ensures that security issues in the codebase are identified and reported efficiently.
+1. `actions/checkout@v4` — checks out source
+2. `codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` — runs Codacy CLI; outputs `results.sarif`; `max-allowed-issues: 2147483647` defers PR rejection to GitHub
+3. `github/codeql-action/upload-sarif@v3` — uploads `results.sarif` to GitHub code scanning
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|-------|
+| `CODACY_PROJECT_TOKEN` | repo | Authenticate with the Codacy project |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `codacy/codacy-analysis-cli-action` | `562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` | v4.4.7 |
+| `github/codeql-action/upload-sarif` | tag ref `v3` | — |
+
+---
+
+## Known Limitations / Notes
+
+- Codacy CLI v4.4.7 is the latest available release. A known Java charset decoder bug (`MalformedInputException: Input length = 2`) causes the workflow to crash when checkov outputs code snippets from modified multi-line YAML files. Mitigated in this repo by `.checkov.yaml` (skips `github_actions` framework). Individual synced repos that modify complex YAML workflows may need the same `.checkov.yaml`.
+- `dependabot[bot]` actors are excluded.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/codacy.md
+++ b/workflow-docs/codacy.md
@@ -19,7 +19,7 @@ Performs a Codacy security scan of the codebase and uploads results in SARIF for
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~2–3 min |
 | Concurrency | none |

--- a/workflow-docs/codeql.md
+++ b/workflow-docs/codeql.md
@@ -1,36 +1,81 @@
-## Workflow Name: CodeQL
+# `codeql.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow automates the process of scanning code for vulnerabilities using GitHub's CodeQL analysis.
+Runs GitHub CodeQL semantic analysis on JavaScript/TypeScript source code, scanning for vulnerabilities and quality issues. Results are surfaced in the GitHub Security tab.
 
-#### Trigger Events:
+---
 
-`Push`: Runs on pushes to the dev and main branches.
+## Trigger
 
-`Pull Requests`: Runs on pull requests targeting dev and main.
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[dev, main]` |
+| `pull_request` | branches: `[dev, main]` |
+| `schedule` | `34 0 * * 4` (Thursday 00:34 UTC) |
 
-`Scheduled`: Runs every Thursday at 00:34 UTC.
+---
 
-#### Permissions:
+## Execution Context
 
-`actions: read`
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~3–5 min |
+| Concurrency | none |
+| Permissions | `actions: read`, `contents: read`, `security-events: write` |
 
-`contents: read`
+---
 
-`security-events: write`
+## Jobs
 
-#### Workflow Steps:
+### `analyze` — Analyze
 
-- Checkout Repository: Uses actions/checkout@v4 to clone the repository.
-  
-- Initialize CodeQL: Prepares the CodeQL environment for the specified languages.
-  
-- Autobuild: Automatically builds the codebase (useful for compiled languages).
-  
-- Perform CodeQL Analysis: Executes the CodeQL scan and uploads results.
-  
-#### Language Support:
-The workflow is configured to scan JavaScript code but can be extended to support other languages like Java, Python, Go, etc.
+**Matrix:** `language: [javascript]`
 
-This setup ensures that your code is continuously analyzed for security vulnerabilities and quality issues.
+**Steps:**
+
+1. `actions/checkout@v4` — checks out source
+2. `github/codeql-action/init@v3` — initialises CodeQL toolchain for JavaScript
+3. `github/codeql-action/autobuild@v3` — automatically builds the project
+4. `github/codeql-action/analyze@v3` — performs analysis and uploads results
+
+---
+
+## Required Secrets
+
+None (uses default `GITHUB_TOKEN`).
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+| `github/codeql-action/init` | tag ref `v3` | — |
+| `github/codeql-action/autobuild` | tag ref `v3` | — |
+| `github/codeql-action/analyze` | tag ref `v3` | — |
+
+---
+
+## Known Limitations / Notes
+
+- Language matrix is fixed to `javascript`; CodeQL treats JS and TS together under the `javascript` language key — no change needed for TypeScript repos.
+- `dependabot[bot]` actors are excluded.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/codeql.md
+++ b/workflow-docs/codeql.md
@@ -19,7 +19,7 @@ Runs GitHub CodeQL semantic analysis on JavaScript/TypeScript source code, scann
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~3–5 min |
 | Concurrency | none |

--- a/workflow-docs/conventional-commits.md
+++ b/workflow-docs/conventional-commits.md
@@ -1,25 +1,73 @@
-## Workflow Name: PR Conventional Commit Validation
+# `conventional-commits.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow automatically validates the title of a pull request (PR) to ensure it follows conventional commit guidelines. It also applies corresponding GitHub labels based on the commit type.
+Validates the PR title against the Conventional Commits specification and automatically applies a corresponding GitHub label (e.g. `bug`, `enhancement`, `CI/CD`) to the PR.
 
-- Uses the ytanikin/PRConventionalCommits@1.1.0 action.
+---
 
-- Validates the PR title against a set of predefined conventional commit types (e.g., feat, fix, docs).
+## Trigger
 
-- Maps these types to corresponding GitHub labels and applies them to the PR.
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | types: `[opened, synchronize, reopened, edited]` |
 
-- Utilizes a GitHub token for authentication and label management.
+---
 
-- This workflow helps enforce commit message conventions and improve PR management by automatically labeling PRs based on their titles.
+## Execution Context
 
-#### Trigger Events:
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~20 s |
+| Concurrency | none |
+| Permissions | default (`GITHUB_TOKEN`) |
 
-`Pull Request Events`: The workflow is triggered when a pull request is opened, synchronized, reopened, or edited.
+---
 
-#### Workflow Steps:
+## Jobs
 
-- Checkout Code: Uses actions/checkout@v4 to check out the repository.
+### `validate-pr-title` — PR Conventional Commit Validation
 
-- PR Conventional Commit Validation:
+**Steps:**
+
+1. `actions/checkout@v4` — checks out source
+2. `ytanikin/PRConventionalCommits@1.1.0` — validates title; accepted types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `feat!`; applies label on match
+
+---
+
+## Required Secrets
+
+None (uses auto-provided `GITHUB_TOKEN`).
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+| `ytanikin/PRConventionalCommits` | tag ref `1.1.0` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- GitHub labels must exist in the target repo before the action can apply them; the action will silently skip label creation if they are missing.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/conventional-commits.md
+++ b/workflow-docs/conventional-commits.md
@@ -17,7 +17,7 @@ Validates the PR title against the Conventional Commits specification and automa
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~20 s |
 | Concurrency | none |

--- a/workflow-docs/dco-check.md
+++ b/workflow-docs/dco-check.md
@@ -17,7 +17,7 @@ Checks that every commit in a pull request includes a `Signed-off-by:` line, enf
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~20 s |
 | Concurrency | none |

--- a/workflow-docs/dco-check.md
+++ b/workflow-docs/dco-check.md
@@ -1,25 +1,73 @@
-## Workflow Name: DCO (Developer Certificate of Origin)
+# `dco-check.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow automatically checks whether each commit in a pull request (PR) has a "Signed-off-by" line, ensuring compliance with the Developer Certificate of Origin (DCO).
+Checks that every commit in a pull request includes a `Signed-off-by:` line, enforcing Developer Certificate of Origin (DCO) compliance across all contributions.
 
-- Retrieves commits between the head and base branches.
+---
 
-- Verifies that each commit contains a "Signed-off-by" line.
+## Trigger
 
-- Lists any non-compliant commits and fails the job if any are found.
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | all types |
 
-- This workflow enforces DCO compliance, ensuring that all contributions are properly signed off, indicating that the contributor agrees to the terms of the DCO.
+---
 
-#### Trigger Events:
+## Execution Context
 
-`Pull Request`: The workflow triggers whenever a pull request event occurs (e.g., opened, updated).
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~20 s |
+| Concurrency | none |
+| Permissions | default |
 
-#### Workflow Steps:
+---
 
-- Checkout Repository:
+## Jobs
 
-- Set Up Environment Variables:
+### `dco` — DCO
 
-- Check for DCO Sign-off:
+**Steps:**
+
+1. `actions/checkout@v4` — full history fetch (`fetch-depth: 0`)
+2. `Set up environment variables` — captures `BASE_BRANCH` and `HEAD_BRANCH` from PR context
+3. `Check for DCO Sign-off` — iterates commits between head and base; fails listing non-compliant SHAs
+
+---
+
+## Required Secrets
+
+None.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- The `git log` range uses `origin/HEAD_BRANCH..origin/BASE_BRANCH`, which gives commits present in the base but absent from the head — the reverse of what a DCO check requires. The correct range is `origin/BASE_BRANCH..origin/HEAD_BRANCH`. This is a latent bug; the check may pass silently on PRs that contain unsigned commits.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/dependency-review.md
+++ b/workflow-docs/dependency-review.md
@@ -17,7 +17,7 @@ Scans dependency manifest file changes in pull requests and blocks merging if ne
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~30 s |
 | Concurrency | none |

--- a/workflow-docs/dependency-review.md
+++ b/workflow-docs/dependency-review.md
@@ -1,25 +1,72 @@
-## Workflow Name: Dependency Review
+# `dependency-review.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow automatically reviews the dependencies of a project whenever a pull request (PR) is opened or updated, ensuring that new dependencies are checked for security vulnerabilities and other issues.
+Scans dependency manifest file changes in pull requests and blocks merging if newly added or updated dependencies contain known security vulnerabilities.
 
-- This workflow helps maintain the security and stability of your project by automatically reviewing new or updated dependencies in pull requests.
+---
 
-#### Trigger Events:
+## Trigger
 
-`Pull Request`: The workflow runs whenever a pull request is created or updated.
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | all types |
 
-#### Permissions:
+---
 
-`Contents`: read: Grants the action read-only access to the repository contents.
+## Execution Context
 
-- Runs on: ubuntu-latest
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~30 s |
+| Concurrency | none |
+| Permissions | `contents: read` |
 
-#### Workflow Steps:
+---
 
-- Checkout Repository:
+## Jobs
 
-- Dependency Review:
+### `dependency-review` — Dependency Review
 
-Uses actions/dependency-review-action@v4 to analyze the dependencies of the project and identify any potential issues.
+**Steps:**
+
+1. `actions/checkout@v4` — checks out source
+2. `actions/dependency-review-action@v4` — reviews dependency manifests; fails PR if vulnerable versions are introduced
+
+---
+
+## Required Secrets
+
+None.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+| `actions/dependency-review-action` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- Requires GitHub Advanced Security (or a public repo) for results to be enforced as a blocking check.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/dockerfile-linter.md
+++ b/workflow-docs/dockerfile-linter.md
@@ -19,7 +19,7 @@ Lints `Dockerfile` using Hadolint, a Haskell-based Dockerfile linter that enforc
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~30 s |
 | Concurrency | none |

--- a/workflow-docs/dockerfile-linter.md
+++ b/workflow-docs/dockerfile-linter.md
@@ -1,37 +1,77 @@
-## Workflow Name: Hadolint
+# `dockerfile-linter.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow automates the linting of Dockerfiles using Hadolint and uploads the results to GitHub in SARIF format for further analysis.
+Lints `Dockerfile` using Hadolint, a Haskell-based Dockerfile linter that enforces Docker best practices, and uploads SARIF results to GitHub Advanced Security.
 
-- This workflow ensures that Dockerfiles are automatically checked for best practices and potential issues, with results easily accessible within GitHub.
+---
 
-#### Trigger Events:
+## Trigger
 
-`Push`: Runs on pushes to the dev and main branches.
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[dev, main]` |
+| `pull_request` | branches: `[dev]` |
+| `schedule` | `17 13 * * 0` (Sunday 13:17 UTC) |
 
-`Pull Request`: Runs on pull requests targeting the dev branch.
+---
 
-`Scheduled`: Runs every Sunday at 13:17 UTC.
+## Execution Context
 
-#### Permissions:
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~30 s |
+| Concurrency | none |
+| Permissions | `contents: read`, `security-events: write`, `actions: read` |
 
-`Contents: read:` Grants read-only access to the repository contents.
+---
 
-`Security-events: write:` Allows uploading SARIF results.
+## Jobs
 
-`Actions: read:` Required for private repositories to retrieve Action run status.
+### `hadolint` — Run hadolint scanning
 
-- Runs on: ubuntu-latest
+**Steps:**
 
-#### Workflow Steps:
+1. `actions/checkout@v4` — checks out source
+2. `hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183` — lints `./Dockerfile`; outputs `hadolint-results.sarif`; `no-fail: true` allows SARIF generation even on findings
+3. `github/codeql-action/upload-sarif@v3` — uploads SARIF to GitHub code scanning
 
-- Checkout Code
+---
 
-- Run Hadolint
+## Required Secrets
 
-Generates a SARIF file with the results.
+None.
 
-- Upload Analysis Results:
+---
 
-Uses github/codeql-action/upload-sarif@v2 to upload the SARIF file to GitHub for security analysis and code scanning.
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file — a no-op if the repo has no `Dockerfile` |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+| `hadolint/hadolint-action` | `f988afea3da57ee48710a9795b6bb677cc901183` | — |
+| `github/codeql-action/upload-sarif` | tag ref `v3` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- The workflow always targets `./Dockerfile` at the repo root; repos with Dockerfiles at other paths will not be linted without a local override.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/dockerhub-image-build-rc.md
+++ b/workflow-docs/dockerhub-image-build-rc.md
@@ -1,8 +1,8 @@
-# `dockerhub-image-build.yml`
+# `dockerhub-image-build-rc.yml`
 
 ## Purpose
 
-Builds a Docker image and pushes it to Docker Hub with a version tag derived from `package.json` (e.g. `3.1.0`) whenever a release is published or code is merged to `main`.
+Builds a Docker image and pushes it to Docker Hub with a floating `:rc` tag whenever code is merged to `dev`. Provides a testable release-candidate image without overwriting the stable production tag.
 
 ---
 
@@ -10,15 +10,15 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 
 | Event | Conditions |
 |-------|-----------|
-| `push` | branches: `[main]` |
-| `release` | types: `[published]` |
+| `push` | branches: `[dev]` |
+| `workflow_dispatch` | manual |
 
 ---
 
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~5–8 min |
 | Concurrency | none |
@@ -35,18 +35,17 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 1. `actions/checkout@v4` — checks out source
 2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
 3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
-4. `Get package version` — reads `VERSION` from `package.json` via `node -p`; sets step output `VERSION`
-5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`
-6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583298` — builds and pushes image; passes `GH_TOKEN` as build arg
-7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates and pushes build attestation to Sigstore transparency log
-8. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=rc`
+5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds and pushes image; passes `GH_TOKEN` as build arg for private package access
+6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates local build attestation (`push-to-registry: false` — RC builds are not published to the Sigstore transparency log)
+7. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
 
 ---
 
 ## Required Secrets
 
 | Secret | Scope | Purpose |
-|--------|-------|-------|
+|--------|-------|---------|
 | `DOCKER_USERNAME` | org | Docker Hub login |
 | `DOCKER_PASSWORD` | org | Docker Hub password |
 | `GH_TOKEN` | org | `npm ci` build arg for private package access |
@@ -57,7 +56,7 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 ## Sync Distribution
 
 | Group | Behaviour |
-|-------|----------|
+|-------|-----------|
 | `REPOS` (service repos) | Receives this file |
 | `SPECIFIC_REPOS` | **Excluded** — library/non-Docker repos do not build Docker images |
 
@@ -66,7 +65,7 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 ## Dependencies (pinned actions)
 
 | Action | Pinned SHA | Semver alias |
-|--------|-----------|----------|
+|--------|-----------|--------------|
 | `actions/checkout` | tag ref `v4` | — |
 | `docker/login-action` | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v3 |
 | `docker/metadata-action` | `030e881283bb7a6894de51c315a6bfe6a94e05cf` | v5 |
@@ -77,8 +76,8 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 
 ## Known Limitations / Notes
 
+- The `:rc` tag is a floating pointer overwritten on every push to `dev`. Use a version-pinned prerelease tag (e.g. `1.2.3-rc.4`) for reproducible deployments.
 - `dependabot[bot]` actors are excluded.
-- Version tag is read from `package.json` at build time; if `package.json` version is stale the wrong tag will be pushed. `version-check.yml` guards against prerelease versions reaching `main` in library repos, but service repos have no equivalent guard.
 
 ---
 

--- a/workflow-docs/dockerhub-image-build.md
+++ b/workflow-docs/dockerhub-image-build.md
@@ -18,7 +18,7 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~5–8 min |
 | Concurrency | none |
@@ -37,7 +37,7 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
 4. `Get package version` — reads `VERSION` from `package.json` via `node -p`; sets step output `VERSION`
 5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`
-6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583298` — builds and pushes image; passes `GH_TOKEN` as build arg
+6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds and pushes image; passes `GH_TOKEN` as build arg
 7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates and pushes build attestation to Sigstore transparency log
 8. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
 

--- a/workflow-docs/docs-template.md
+++ b/workflow-docs/docs-template.md
@@ -1,0 +1,90 @@
+# `<workflow-filename>.yml`
+
+## Purpose
+
+One or two sentences describing what this workflow does and why it exists.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[main, dev]` |
+| `workflow_dispatch` | manual only |
+| `schedule` | `0 4 * * 1` (weekly Monday 04:00 UTC) |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Typical duration | ~2 min |
+| Concurrency | none / `cancel-in-progress: true` |
+| Permissions | `contents: read`, `security-events: write` |
+
+---
+
+## Jobs
+
+### `<job-id>` — <short description>
+
+**Steps:**
+
+1. `actions/checkout@<sha>` — checks out source
+2. `<step name>` — <what it does>
+3. ...
+
+**Outputs:** _(if any)_
+
+| Output | Set by step | Description |
+|--------|------------|-------------|
+| `VERSION` | `pkg_version` | Semver string from `package.json` |
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `GH_TOKEN` | repo | Clone and push to target repos |
+| `DOCKERHUB_USERNAME` | org | Docker Hub login |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `REPOS` | Receives this file |
+| `SPECIFIC_REPOS` | **Excluded** — reason |
+| `PUBLISH_REPOS` | **Excluded** — reason |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | `11bd71901...` | `v4` |
+| `docker/login-action` | `9ec57ed1f...` | `v3` |
+
+---
+
+## Known Limitations / Notes
+
+- Bullet list of gotchas, edge cases, or deferred work items with issue links.
+
+---
+
+## Repository Overrides
+
+Repos that maintain their own copy of this workflow instead of receiving it via sync, and the reason why:
+
+| Repository | Reason |
+|-----------|--------|
+| `relay-service` | Custom multi-plugin Docker matrix (multiple images built per run); canonical single-image workflow cannot represent this |
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/gpg-verify.md
+++ b/workflow-docs/gpg-verify.md
@@ -17,7 +17,7 @@ Verifies that every commit in a pull request has a valid GPG signature using the
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~20–30 s |
 | Concurrency | none |

--- a/workflow-docs/gpg-verify.md
+++ b/workflow-docs/gpg-verify.md
@@ -1,27 +1,74 @@
-## Workflow Name: GPG Verify
+# `gpg-verify.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow automatically verifies the GPG signatures of commits in a pull request, ensuring that all commits are signed and verified as part of the code review process.
+Verifies that every commit in a pull request has a valid GPG signature using the GitHub REST API, ensuring that only verified commits can be merged.
 
-- This workflow helps enforce the use of GPG-signed commits, adding an extra layer of security to the contribution process.
+---
 
-- If any commit fails the GPG verification, the workflow fails, ensuring only verified commits are merged.
+## Trigger
 
-#### Trigger Events:
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | all types |
 
-`Pull Request`: The workflow triggers whenever a pull request is opened or updated.
+---
 
-- Runs on: ubuntu-latest
+## Execution Context
 
-#### Workflow Steps:
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~20–30 s |
+| Concurrency | none |
+| Permissions | default |
 
-- Checkout Repository:
+---
 
-- Set Up Environment Variables:
+## Jobs
 
-Captures the head and base references of the pull request and sets up necessary environment variables.
+### `gpg-verify` — GPG Verify
 
-- Check GPG Verification Status:
+**Steps:**
 
-Retrieves the list of commits in the pull request. For each commit, it checks the GPG verification status using GitHub's API.
+1. `actions/checkout@v4` — full history fetch (`fetch-depth: 0`)
+2. `Set up environment variables` — captures `PR_HEAD_REF`, `PR_BASE_REF`, `GITHUB_TOKEN`, `GITHUB_REPOSITORY`
+3. `Check GPG verification status` — iterates commits via `git log`; queries `/repos/:repo/commits/:sha/check-runs` for each; fails if any GPG check run conclusion is not `success`
+
+---
+
+## Required Secrets
+
+None (uses auto-provided `GITHUB_TOKEN`).
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- The check queries the `check-runs` API endpoint for each commit individually, which may hit API rate limits on large PRs.
+- The lookup relies on a check run named `"GPG verify"` already existing. On first-run PRs there may be a race condition where the check run is not yet present, causing spurious failures.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/milestone.md
+++ b/workflow-docs/milestone.md
@@ -1,31 +1,77 @@
-## Workflow Name: Milestone Workflow
+# `milestone.yml`
 
-#### Purpose: 
+## Purpose
 
-- This workflow is designed to close a specific milestone on GitHub and trigger a release workflow. It is manually triggered with a specified milestone ID.
+Closes a GitHub milestone and triggers the `release.yml` workflow via `repository_dispatch`, linking milestone completion to the automated release process.
 
-- This workflow streamlines the process of managing milestones and automates the transition to the release process.
+---
 
-#### Trigger Events:
+## Trigger
 
-`Workflow Dispatch`: This workflow is triggered manually with a milestoneId input.
+| Event | Conditions |
+|-------|-----------|
+| `workflow_dispatch` | input: `milestoneId` (required) |
 
-- Runs on: ubuntu-latest
+---
 
-#### Workflow Steps:
+## Execution Context
 
-- Checkout Repository:
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~30 s |
+| Concurrency | none |
+| Permissions | default (`GITHUB_TOKEN`) |
 
-Uses actions/checkout@v2 to clone the repository.
+---
 
-- Set Up Environment Variables:
+## Jobs
 
-Sets up necessary environment variables, including the GitHub token, milestone number, and GitHub API URL.
+### `close_milestone` — close milestone and trigger release
 
-- Close Milestone:
+**Steps:**
 
-Uses the GitHub API to close the specified milestone.
+1. `actions/checkout@v2` — checks out source
+2. `Set up environment variables` — sets `ACCESS_TOKEN`, `MILESTONE_NUMBER`, `API_URL`
+3. `Close Milestone` — calls `PATCH /repos/:repo/milestones/:number` with `{"state": "closed"}`
+4. `Trigger Release Workflow` — `peter-evans/repository-dispatch@v1` fires `release` event with `milestone_number` payload
 
-- Trigger Release Workflow:
+---
 
-Triggers another workflow for releasing, passing the milestone number as a payload using the peter-evans/repository-dispatch@v1 action.
+## Required Secrets
+
+None (uses auto-provided `GITHUB_TOKEN`).
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v2` | — |
+| `peter-evans/repository-dispatch` | tag ref `v1` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- Uses `actions/checkout@v2` — should be upgraded to `v4` to align with all other workflows.
+- `peter-evans/repository-dispatch@v1` is not pinned to a SHA; should be pinned per GitHub hardening recommendations.
+- The milestone is closed before the release workflow is confirmed to have started; if the dispatch fails, the milestone remains closed without a release created.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/milestone.md
+++ b/workflow-docs/milestone.md
@@ -17,7 +17,7 @@ Closes a GitHub milestone and triggers the `release.yml` workflow via `repositor
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~30 s |
 | Concurrency | none |

--- a/workflow-docs/njsscan.md
+++ b/workflow-docs/njsscan.md
@@ -19,7 +19,7 @@ Runs the njsscan (nodejsscan) static security scanner against the Node.js codeba
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~1–2 min |
 | Concurrency | none |

--- a/workflow-docs/njsscan.md
+++ b/workflow-docs/njsscan.md
@@ -1,32 +1,76 @@
-## Workflow Name: njsscan sarif
+# `njsscan.yml`
 
-#### Purpose:
+## Purpose
 
-- This GitHub workflow is designed to run the njsscan code scanning tool and upload the results as a SARIF (Static Analysis Results Interchange Format) report to GitHub. Here's a detailed breakdown of the workflow:
+Runs the njsscan (nodejsscan) static security scanner against the Node.js codebase to identify insecure code patterns, and uploads results as SARIF to GitHub Advanced Security.
 
-- This workflow ensures that every push and pull request to the dev and main branches, as well as a weekly scheduled run, triggers a security scan using njsscan. The results are then uploaded to GitHub in SARIF format, allowing the repository maintainers to review and address potential security issues.
+---
 
-#### Trigger Events
+## Trigger
 
-`push`:
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[dev, main]` |
+| `pull_request` | branches: `[dev, main]` |
+| `schedule` | `17 17 * * 1` (Monday 17:17 UTC) |
 
-`branches: [ "dev", "main" ]`: The workflow will trigger whenever there is a push to the dev or main branches.
+---
 
-`pull_request`:
+## Execution Context
 
-`branches: [ "dev", "main" ]`: The workflow will also trigger when a pull request is made targeting the dev or main branches.
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~1–2 min |
+| Concurrency | none |
+| Permissions | `contents: read`, `security-events: write`, `actions: read` |
 
-`schedule`:
+---
 
-`cron: '17 17 * * 1'`: The workflow is scheduled to run automatically every Monday at 17:17 UTC.
+## Jobs
 
+### `njsscan` — njsscan code scanning
 
-#### permissions:
+**Steps:**
 
-`contents`: read: Grants read access to the repository contents for the entire workflow.
+1. `actions/checkout@v4` — checks out source
+2. `ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81` — scans `.`; outputs `results.sarif`; `|| true` ensures SARIF is always generated even when issues are found
+3. `github/codeql-action/upload-sarif@v3` — uploads `results.sarif`
 
-#### Workflow Steps
+---
 
-- Checkout the code
+## Required Secrets
 
-- njsscan
+None.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+| `ajinabraham/njsscan-action` | `d58d8b2f26322cd35a9efb8003baac517f226d81` | — |
+| `github/codeql-action/upload-sarif` | tag ref `v3` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/nodejs.md
+++ b/workflow-docs/nodejs.md
@@ -1,83 +1,102 @@
-## Workflow Name: Node.js CI
+# `node.js.yml`
 
-#### Purpose:
+## Purpose
 
-- This GitHub workflow is designed for Continuous Integration (CI) of a Node.js project. It includes three jobs: building the project, checking the code style, and running tests. Here's a detailed breakdown of the workflow:
+Node.js CI pipeline with three parallel jobs — build, lint, and test — running against Node.js 20. Validates that the project compiles, passes linting rules, and all tests pass on every push and pull request to `dev` and `main`.
 
-#### Environment Variables
+---
 
-`env`:
+## Trigger
 
-`GH_TOKEN`: ${{ secrets.GITHUB_TOKEN }}: A secret token used to authenticate with GitHub, stored securely in GitHub secrets.
-NPM_SCOPE`: "@frmscoe": The scope for the npm packages, typically used for scoped packages.
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[dev, main]` |
+| `pull_request` | branches: `[dev, main]` |
 
-``NPM_REGISTRY`: "https://npm.pkg.github.com/": The npm registry URL where the scoped packages are hosted.
+---
 
-`NODE_ENV`: 'test': The environment variable used to specify the environment as 'test'.
+## Execution Context
 
-`STARTUP_TYPE`: 'nats': A custom environment variable indicating the type of startup, possibly related to the messaging system used in the project.
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Typical duration | ~2–5 min |
+| Concurrency | none |
+| Permissions | default |
 
-#### Triggers Events
+---
 
-`push`:
+## Environment Variables
 
-`branches: [ "dev", "main" ]`: The workflow triggers on a push to the dev or main branches.
+| Variable | Value | Purpose |
+|----------|-------|--------|
+| `GH_TOKEN` | `secrets.GITHUB_TOKEN` | npm auth for private packages |
+| `NPM_SCOPE` | `@frmscoe` | npm scope for registry routing |
+| `NPM_REGISTRY` | `https://npm.pkg.github.com/` | GitHub Packages registry |
+| `NODE_ENV` | `test` | sets test environment |
+| `STARTUP_TYPE` | `nats` | messaging system type expected by some tests |
 
-`pull_request`:
+---
 
-`branches: [ "dev", "main" ]`: The workflow also triggers when a pull request is opened targeting the dev or main branches.
-Jobs
+## Jobs
 
-- The workflow is divided into three jobs: `build`, `lint`, and `test`.
+### `build` — run build
 
-1. Build Job
+1. `actions/checkout@v4`
+2. `actions/setup-node@v4` — Node 20, npm cache, registry and scope
+3. `npm ci`
+4. `npm run build`
 
-#### build:
+### `lint` — check style
 
-- runs-on: ubuntu-latest: This job runs on the latest available version of Ubuntu.
+1. `actions/checkout@v4`
+2. `actions/setup-node@v4`
+3. `npm ci`
+4. `npm run lint`
 
-- steps:
+### `test` — check tests
 
-Checkout the code:
+1. `actions/checkout@v4`
+2. `actions/setup-node@v4`
+3. `npm ci`
+4. `npm test`
 
-Install dependencies:
+---
 
-run: npm ci: Installs the project dependencies using npm in a clean environment.
+## Required Secrets
 
-Run build:
+| Secret | Scope | Purpose |
+|--------|-------|-------|
+| `GITHUB_TOKEN` | auto | npm authentication via `GH_TOKEN` |
 
-run: npm run build: Executes the build script to compile the project.
+---
 
-2. Lint Job
+## Sync Distribution
 
-#### lint:
+| Group | Behaviour |
+|-------|----------|
+| **All repos** | **Excluded from sync** — `node.js.yml` is explicitly removed before the sync bundle is assembled; every repo maintains its own copy |
 
-- runs-on: ubuntu-latest: The job runs on the latest Ubuntu version.
+---
 
-- steps:
+## Dependencies (pinned actions)
 
-Checkout code:
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+| `actions/setup-node` | tag ref `v4` | — |
 
-Install dependencies:
+---
 
-Check linting:
+## Known Limitations / Notes
 
-3. Test Job
+- Excluded from sync to preserve per-repo customisations (some repos have additional jobs or environment-specific configurations). Any changes to the canonical file must be propagated manually to each repo (see `update-workflows.md` Track A6 / Track B4).
+- `NPM_SCOPE` is set to `@frmscoe`; this is intentional as many private packages are still published under the `@frmscoe` scope.
+- `dependabot[bot]` actors are excluded.
 
-#### test:
+---
 
-- runs-on: ubuntu-latest: The job runs on Ubuntu.
+## Repository Overrides
 
-steps:
-
-Checkout code:
-
-Install dependencies:
-
-Run tests:
-
-#### Summary
-
-- This workflow is a complete CI pipeline for a Node.js project. It tests the code on multiple Node.js versions, checks the code style, and runs the build process. 
-
-- The environment variables and registry settings are configured to work with a specific npm scope hosted on GitHub. The workflow runs on pushes and pull requests to the dev and main branches, ensuring continuous integration of the project code.
+Not applicable — this workflow is not synced; every repo maintains its own copy. Some repos previously had a `bench` job included in this file; that job is being removed via separate PRs.

--- a/workflow-docs/nodejs.md
+++ b/workflow-docs/nodejs.md
@@ -18,7 +18,7 @@ Node.js CI pipeline with three parallel jobs — build, lint, and test — runni
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Node version | `20` |
 | Typical duration | ~2–5 min |

--- a/workflow-docs/package-rule-rc.md
+++ b/workflow-docs/package-rule-rc.md
@@ -1,0 +1,99 @@
+# `package-rule-rc.yml`
+
+## Purpose
+
+Reusable workflow that automates building and pushing a release-candidate Docker image for a rule processor. It clones `rule-executer` (dev branch), patches the rule number and version, builds the image, and pushes it with both a versioned prerelease tag (e.g. `1.0.0-rc.2`) and a floating `:rc` pointer.
+
+Called from a caller stub `package-rule-rc.yml` in each rule repo rather than being copied in full.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `workflow_call` | called from rule repo caller stub |
+
+---
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `rule_number` | yes | Zero-padded rule number (e.g. `"001"`, `"901"`) |
+| `rule_org` | yes | GitHub org owning the rule repo (`"tazama-lf"` or `"frmscoe"`) |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Typical duration | ~5–10 min |
+| Concurrency | none |
+| Permissions | `contents: read` |
+
+---
+
+## Jobs
+
+### `automate-rule-executer`
+
+**Steps:**
+
+1. `actions/checkout@v4` — checks out rule repo source
+2. `actions/setup-node@v4` — Node 20
+3. `Read rule version from package.json` — reads `version`; fails if version is NOT a prerelease (`-` suffix required — guards against RC build running on a stable version)
+4. `Clone Rule Executer repository (dev branch)` — clones `tazama-lf/rule-executer@dev`
+5. `Prepare rule-executer-<N>` — copies cloned directory
+6. `Modify package.json and Dockerfile for rule <N>` — patches rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
+7. `Install dependencies` — `npm ci` in the patched directory
+8. `Build and push RC Docker image` — builds once; tags with `VERSION` and `:rc`; pushes both
+9. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `GH_TOKEN_LIB` | org | `npm ci` for private packages; checkout token |
+| `DOCKER_USERNAME` | org | Docker Hub login |
+| `DOCKER_PASSWORD` | org | Docker Hub password |
+| `SLACK_WEBHOOK_URL` | org | Slack notification |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `RULE_REPOS` (`rule-901`, `rule-902`) | Receives a **caller stub** — the canonical reusable definition lives only in `tazama-lf/workflows` |
+| All other repos | **Not distributed** |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | tag ref `v4` | — |
+| `actions/setup-node` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- Rule repo caller stubs also trigger on `repository_dispatch: types: [rule-executer-update]`, enabling rule images to be rebuilt when `rule-executer` itself changes without needing a new commit in the rule repo.
+- The `:rc` tag is a floating pointer overwritten on every push to `dev`. Use the versioned tag (e.g. `1.0.0-rc.2`) for reproducible deployments.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all rule repos use the canonical reusable workflow via their caller stub)_ |

--- a/workflow-docs/package-rule.md
+++ b/workflow-docs/package-rule.md
@@ -1,0 +1,99 @@
+# `package-rule.yml`
+
+## Purpose
+
+Reusable workflow that automates building and pushing a stable Docker image for a rule processor. It clones `rule-executer` (main branch), patches the rule number and version into `package.json` and `Dockerfile`, builds the image, and pushes it with both a versioned stable tag (e.g. `1.0.0`) and a floating `:latest` pointer.
+
+Called from a caller stub `package-rule.yml` in each rule repo rather than being copied in full.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `workflow_call` | called from rule repo caller stub |
+
+---
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `rule_number` | yes | Zero-padded rule number (e.g. `"001"`, `"901"`) |
+| `rule_org` | yes | GitHub org owning the rule repo (`"tazama-lf"` or `"frmscoe"`) |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Typical duration | ~5–10 min |
+| Concurrency | none |
+| Permissions | `contents: read` |
+
+---
+
+## Jobs
+
+### `automate-rule-executer`
+
+**Steps:**
+
+1. `actions/checkout@v4` — checks out rule repo source
+2. `actions/setup-node@v4` — Node 20
+3. `Read rule version from package.json` — reads `version`; fails if version is a prerelease (guards against stable build running on a prerelease version)
+4. `Clone Rule Executer repository (main branch)` — clones `tazama-lf/rule-executer@main`
+5. `Prepare rule-executer-<N>` — copies cloned directory
+6. `Modify package.json and Dockerfile for rule <N>` — patches rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
+7. `Install dependencies` — `npm ci` in the patched directory
+8. `Build and push stable Docker image` — builds once; tags with `VERSION` and `:latest`; pushes both
+9. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `GH_TOKEN_LIB` | org | `npm ci` for private packages; checkout token |
+| `DOCKER_USERNAME` | org | Docker Hub login |
+| `DOCKER_PASSWORD` | org | Docker Hub password |
+| `SLACK_WEBHOOK_URL` | org | Slack notification |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `RULE_REPOS` (`rule-901`, `rule-902`) | Receives a **caller stub** — the canonical reusable definition lives only in `tazama-lf/workflows` |
+| All other repos | **Not distributed** |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | tag ref `v4` | — |
+| `actions/setup-node` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- Fails explicitly if version IS a prerelease — the `version-check.yml` guard on `main` PRs provides a second line of defence for library repos, but this redundant check prevents an accidental stable-build run if branch protection is bypassed.
+- The `checkov:skip=CKV_GHA_7` annotation suppresses a false-positive: the `version` input variable is emitted by a `node -p` read of `package.json` and controls only the Docker tag, not the build artifact source.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all rule repos use the canonical reusable workflow via their caller stub)_ |

--- a/workflow-docs/publish.md
+++ b/workflow-docs/publish.md
@@ -1,0 +1,86 @@
+# `publish.yml`
+
+## Purpose
+
+Publishes a Node.js package to GitHub Packages (`@tazama-lf` scope). Prerelease versions (containing `-`) are published under the `rc` dist-tag so they do not become the default `latest` install target; stable versions are published under `latest`. Triggered automatically on merge to `main` or manually via `workflow_dispatch`.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[main]` |
+| `workflow_dispatch` | manual |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Registry | `https://npm.pkg.github.com/` |
+| Scope | `@tazama-lf` |
+| Typical duration | ~1–2 min |
+| Concurrency | none |
+| Permissions | `packages: write`, `contents: read` |
+
+---
+
+## Jobs
+
+### `build-and-publish`
+
+**Steps:**
+
+1. `actions/checkout@v4` — checks out source (token: `GH_TOKEN_LIB`)
+2. `actions/setup-node@v4` — Node 20, GitHub Packages registry, `@tazama-lf` scope
+3. `Set up npm authentication` — appends `_authToken` to `~/.npmrc`
+4. `npm ci` — installs dependencies
+5. `npm run build` — compiles package
+6. `Publish package` — reads version from `package.json`; if version contains `-` publishes with `--tag rc`; otherwise publishes with implicit `latest`
+7. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `GH_TOKEN_LIB` | org | npm publish auth + checkout token |
+| `SLACK_WEBHOOK_URL` | org | Slack notification |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `PUBLISH_REPOS` | Receives this file |
+| All service repos (non-`PUBLISH_REPOS`) | **Excluded** — service repos publish Docker images, not npm packages |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | tag ref `v4` | — |
+| `actions/setup-node` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- Works in conjunction with `version-check.yml` (blocks prerelease merging to `main`) and `release-train.yml` (creates the release PR with stable version). Together these three form the library release pipeline.
+- Resolves tazama-lf/workflows#27.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all PUBLISH_REPOS use the canonical version)_ |

--- a/workflow-docs/release-train.md
+++ b/workflow-docs/release-train.md
@@ -1,0 +1,86 @@
+# `release-train.yml`
+
+## Purpose
+
+Prepares a library release PR from `dev` → `main`. Given a target stable version, it validates the input, resolves all internal `@tazama-lf`/`@frmscoe` rc dependencies to their latest stable equivalents, bumps `package.json`, regenerates `package-lock.json`, then creates a `release/v<N>` branch and opens a PR — all via the GitHub API so that commits are Verified and satisfy branch protection.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `workflow_dispatch` | input: `version` (required, clean semver `X.Y.Z` — no prerelease suffix) |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Registry | `https://npm.pkg.github.com/` |
+| Typical duration | ~2–3 min |
+| Concurrency | none |
+| Permissions | `contents: write`, `pull-requests: write` |
+
+---
+
+## Jobs
+
+### `prepare-release`
+
+**Steps:**
+
+1. `Validate version input` — rejects prerelease suffixes and non-`X.Y.Z` strings
+2. `actions/checkout@v4` — checks out `dev` branch (token: `GH_TOKEN_LIB`)
+3. `actions/setup-node@v4` — Node 20, GitHub Packages registry, `@tazama-lf` scope
+4. `Add @frmscoe registry scope` — appends registry line to `~/.npmrc`
+5. `Resolve internal rc dependencies to stable` — iterates `dependencies`, `devDependencies`, `peerDependencies`; resolves pinned-rc and range-with-rc patterns; fails if `dist-tags.latest` is still a prerelease
+6. `Update version in package.json` — writes the workflow input version
+7. `Regenerate package-lock.json` — runs `npm install --package-lock-only`
+8. `Commit and push to release branch via GitHub API` — creates/resets `release/v<N>` branch at current dev HEAD; builds tree, creates commit, and updates ref via REST API; outputs `branch_name` and `commit_sha`
+9. `Open PR to main via GitHub API` — creates PR targeting `main` with reviewers from `GH_USERNAME` secret
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `GH_TOKEN_LIB` | org | API commits, npm install auth, PR creation |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `PUBLISH_REPOS` | Receives this file |
+| All service repos (non-`PUBLISH_REPOS`) | **Excluded** |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | tag ref `v4` | — |
+| `actions/setup-node` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `checkov:skip=CKV_GHA_7` annotation suppresses a false-positive: the `version` input controls only the release branch name and `package.json` version — not the build artifact source.
+- If `release/v<N>` already exists it is force-reset to the current `dev` HEAD, enabling idempotent reruns without manual cleanup.
+- The PR body does not include an auto-generated changelog; reviewers should compare `dev` to `main` manually before approving.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all PUBLISH_REPOS use the canonical version)_ |

--- a/workflow-docs/release.md
+++ b/workflow-docs/release.md
@@ -1,45 +1,88 @@
-## GitHub Action Workflow Documentation: Release
+# `release.yml`
 
-#### Purpose
+## Purpose
 
-- This GitHub Action workflow, named Release Workflow, automates the process of creating a new release based on merged pull requests, generating a changelog, and updating relevant files like CHANGELOG.md and VERSION. 
+Automates the GitHub release creation process. Triggered by a `repository_dispatch` event (fired by `milestone.yml`), it determines the release type (major/minor/patch) from commit messages, bumps the version, generates a changelog from merged PRs, creates a GitHub release, and updates `CHANGELOG.md` and `VERSION` in the repository.
 
-- The workflow is triggered by a repository_dispatch event, specifically of type release, which can be used to trigger the workflow programmatically.
+---
 
-- This workflow is an automated process that handles the entire release lifecycle, including version bumping, changelog generation, and updating repository files. It's triggered by an external event, making it suitable for use with external tools or scripts that manage release processes. 
+## Trigger
 
-- The workflow is robust, ensuring that all necessary release tasks are completed consistently and accurately.
+| Event | Conditions |
+|-------|-----------|
+| `repository_dispatch` | types: `[release]`; payload: `milestone_number` |
 
-#### Workflow Breakdown
+---
 
-##### Trigger
+## Execution Context
 
-`on: repository_dispatch`: The workflow is triggered by a repository_dispatch event.
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~1–2 min |
+| Concurrency | none |
+| Permissions | default (`GITHUB_TOKEN`) |
 
-`types: [release`]: The workflow listens for the release event type.
+---
 
-`properties: milestone_number`: The workflow accepts a milestone_number property, which is a string representing the milestone ID associated with the release.
+## Jobs
 
-#### Workflow Steps:
+### `release`
 
-- Checkout Repository:
+**Steps:**
 
-- Get the Latest Tag in the Repository:
+1. `actions/checkout@v2` — checks out `main` with full tag history
+2. `actions-ecosystem/action-get-merged-pull-request@v1` — retrieves the last merged PR
+3. `actions-ecosystem/action-release-label@v1` — determines release level from PR labels
+4. `actions-ecosystem/action-get-latest-tag@v1` — gets the latest semver tag
+5. `Determine Release Type` — parses commit messages; maps `BREAKING CHANGE`/`feat!` → major, `feat:` → minor, all others → patch
+6. `Bump Version` — increments the appropriate version component
+7. `Get Milestone Details` — fetches milestone title and description via GitHub API
+8. `Generate Changelog` — compiles changelog from merged PRs since last tag
+9. `Display Changelog` — prints to runner log
+10. `Attach Changelog to Release` — writes changelog content
+11. `Create Release` — creates the GitHub release with the new tag
+12. `Update CHANGELOG.md File` — prepends the new changelog entry
+13. `Update VERSION File` — writes new version string
 
-- Determine Release Type:
+---
 
-- Bump Version:
+## Required Secrets
 
-- Get Milestone Details:
+None (uses auto-provided `GITHUB_TOKEN`).
 
-- Generate Changelog
+---
 
-- Display Changelog:
+## Sync Distribution
 
-- Attach Changelog to Release:
+| Group | Behaviour |
+|-------|----------|
+| All `REPOS` | Receives this file |
 
-- Create Release:
+---
 
-- Update CHANGELOG.md File:
+## Dependencies (pinned actions)
 
-- Update VERSION File:
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v2` | — |
+| `actions-ecosystem/action-get-merged-pull-request` | tag ref `v1` | — |
+| `actions-ecosystem/action-release-label` | tag ref `v1` | — |
+| `actions-ecosystem/action-get-latest-tag` | tag ref `v1` | — |
+
+---
+
+## Known Limitations / Notes
+
+- Uses deprecated `::set-output name=...` syntax; should be migrated to `$GITHUB_OUTPUT`.
+- Uses `actions/checkout@v2`; should be upgraded to `v4`.
+- No actions are pinned to commit SHAs — all use mutable tag refs, which is a supply-chain risk.
+- `dependabot[bot]` actors are excluded.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/release.md
+++ b/workflow-docs/release.md
@@ -17,7 +17,7 @@ Automates the GitHub release creation process. Triggered by a `repository_dispat
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~1–2 min |
 | Concurrency | none |

--- a/workflow-docs/sbom.md
+++ b/workflow-docs/sbom.md
@@ -1,0 +1,74 @@
+# `sbom.yml`
+
+## Purpose
+
+Generates a Software Bill of Materials (SBOM) for the Docker image using Anchore Syft and uploads the results to the GitHub Dependency Submission API, enabling dependency tracking and vulnerability alerting in the GitHub Security tab.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[main]` |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~3–5 min |
+| Concurrency | none |
+| Permissions | `contents: write` |
+
+---
+
+## Jobs
+
+### `Anchore-Build-Scan`
+
+**Steps:**
+
+1. `actions/checkout@v4` — checks out source
+2. `docker build . --file Dockerfile --tag localbuild/testimage:latest` — builds the Docker image locally
+3. `anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a` — scans the image; outputs `image.spdx.json` artifact; submits dependency snapshot to GitHub via Dependency Submission API
+
+---
+
+## Required Secrets
+
+None.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| All `REPOS` | Receives this file |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | tag ref `v4` | — |
+| `anchore/sbom-action` | `bb716408e75840bbb01e839347cd213767269d4a` | — |
+
+---
+
+## Known Limitations / Notes
+
+- `dependabot[bot]` actors are excluded.
+- Synced to all repos including library repos that have no `Dockerfile`; the `docker build` step will fail in those repos. Consider excluding library repos (`PUBLISH_REPOS`) from receiving this file — tracked in tazama-lf/workflows#35.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced repos use the canonical version)_ |

--- a/workflow-docs/scorecard.md
+++ b/workflow-docs/scorecard.md
@@ -1,0 +1,82 @@
+# `scorecard.yml`
+
+## Purpose
+
+Runs the OSSF Scorecard supply-chain security analysis to assess repository security practices (branch protection, dependency pinning, code review requirements, etc.) and publishes results to the OSSF Scorecard badge API and GitHub Advanced Security code scanning.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[main, dev]` |
+| `schedule` | `15 16 * * 0` (Sunday 16:15 UTC) |
+| `branch_protection_rule` | any change to branch protection rules |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~2–3 min |
+| Concurrency | none |
+| Permissions (workflow) | `read-all` |
+| Permissions (job) | `security-events: write`, `id-token: write` |
+
+---
+
+## Jobs
+
+### `analysis` — Scorecard analysis
+
+**Steps:**
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source (`persist-credentials: false`)
+2. `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a` — runs analysis; outputs `results.sarif`; `publish_results=true` only on `main`, `schedule`, or `branch_protection_rule` events — dev-branch runs score the repo but do not overwrite the published badge
+3. `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` — uploads `results.sarif` artifact (5-day retention)
+4. `github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc` — uploads SARIF to code scanning dashboard
+
+---
+
+## Required Secrets
+
+None (uses GitHub OIDC token via `id-token: write`).
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| Service repos (`REPOS` minus `PUBLISH_REPOS`) | Receives this file |
+| `PUBLISH_REPOS` | **Excluded** — scorecard is scoped to service repos only |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
+| `ossf/scorecard-action` | `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` | v2.4.3 |
+| `actions/upload-artifact` | `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` | v7.0.0 |
+| `github/codeql-action/upload-sarif` | `38697555549f1db7851b81482ff19f1fa5c4fedc` | v4.34.1 |
+
+---
+
+## Known Limitations / Notes
+
+- Scorecard enforces strict constraints: no workflow-level `env` or `defaults`; workflow permissions must be `read-all`; `id-token: write` is only permitted at job level.
+- `publish_results` is intentionally `false` on `dev` branch pushes — the public badge and REST API always reflect the default branch score only.
+- Depends on tazama-lf/technical-steering-committee#14 (default branch switch from `dev` to `main`) for the OSSF badge to display the correct score.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all synced service repos use the canonical version)_ |

--- a/workflow-docs/sync-workflows.md
+++ b/workflow-docs/sync-workflows.md
@@ -1,40 +1,93 @@
-## GitHub Action Workflow Documentation: Sync Workflows
+# `sync-workflows.yml`
 
-#### Purpose
+## Purpose
 
-- This GitHub Action workflow automates the process of synchronizing workflow files across multiple repositories whenever a pull request (PR) is merged into the dev branch.
+Propagates canonical workflow files from this repository to all configured target repos. When a PR to `dev` is opened or updated, it clones each target repo, copies the applicable workflow files according to per-file sync rules, and opens a `sync-workflows-update` PR in each target repo. `sync-workflows.yml` and `node.js.yml` are explicitly excluded from the bundle.
 
-- This workflow ensures that all specified repositories maintain consistent CI/CD workflows by automatically syncing changes from a central repository when updates are made.
+---
 
-#### Trigger Event
+## Trigger
 
-`pull_request`
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | branches: `[dev]` (fires on open, update, and close) |
+| `workflow_dispatch` | manual |
 
-`types: [closed]` - This workflow triggers when a pull request is closed.
+---
 
-`branches: [ "dev" ]` - It specifically listens to pull requests merged into the dev branch.
+## Execution Context
 
+| Property | Value |
+|----------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~10–30 min (scales with number of target repos) |
+| Concurrency | none |
+| Permissions | default (plus `GH_TOKEN` for cross-repo operations) |
 
-#### Jobs
+---
 
-- Job: sync
+## Sync Groups
 
-`Condition`:
+| Variable | Contents |
+|----------|---------|
+| `REPOS` | All 26 target repositories (service + library) |
+| `SPECIFIC_REPOS` | Library and non-Docker repos that skip `SPECIFIC_FILES` |
+| `SPECIFIC_FILES` | `dockerhub-image-build.yml dockerhub-image-build-rc.yml` |
+| `PUBLISH_REPOS` | Library repos that receive `publish.yml`, `version-check.yml`, `release-train.yml` but not `scorecard.yml` |
+| `RULE_REPOS` | `rule-901`, `rule-902` — receive caller stubs for `package-rule*.yml` instead of the full canonical |
 
-if: github.event.pull_request.merged == true - This job only runs if the pull request was successfully merged.
+**Org routing:** Library repos (`PUBLISH_REPOS`) are cloned from `tazama-lf`; service repos are currently cloned from `frmscoe`. Full service-repo migration is tracked in [workflows#28](https://github.com/tazama-lf/workflows/issues/28).
 
-- Runs on: ubuntu-latest - The job uses the latest Ubuntu runner.
+---
 
-#### Workflow Steps
+## Jobs
 
-- Checkout Central Workflows Repo
+### `Sync_All_Repos_Common_Workflows`
 
-- Set up Git
+**Steps:**
 
-- Install GitHub CLI
+1. `actions/checkout@v4` — checks out this workflows repo
+2. `Set up Git` — configures git identity for commits
+3. `Install GitHub CLI` — downloads and installs `gh` CLI v2.14.7
+4. `Get PR author details` — captures author name and email for commit attribution
+5. `Sync Workflows to Other Repos` — main loop: clones each repo, checks out or creates `sync-workflows-update` branch, applies per-file sync rules, commits changes, pushes, opens PR
 
-- Get PR author details
+---
 
-- Sync Workflows to Other Repos
+## Required Secrets
 
-- Cleanup: Temporary files used for GitHub CLI authentication are removed after the operation.
+| Secret | Scope | Purpose |
+|--------|-------|-------|
+| `GH_TOKEN` | org | Clone, push, and open PRs against target repos |
+| `GH_USERNAME` | org | PR reviewer assignment |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| **Not synced** | This file is explicitly removed from the sync bundle (`rm temp-workflows/sync-workflows.yml`) |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|----------|
+| `actions/checkout` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- Service repo org URLs still use `frmscoe` (not `tazama-lf`); tracked in [workflows#28](https://github.com/tazama-lf/workflows/issues/28).
+- `gh` CLI is pinned to v2.14.7 via a direct tarball download; should be updated periodically.
+- The workflow fires on all `pull_request` events to `dev`, not just merged ones. This means unmerged PRs trigger sync branches in target repos; reviewers in those repos should not merge `sync-workflows-update` PRs until the source PR is merged.
+- `dependabot[bot]` actors are excluded.
+
+---
+
+## Repository Overrides
+
+Not applicable — this workflow is canonical-only and is never distributed.

--- a/workflow-docs/sync-workflows.md
+++ b/workflow-docs/sync-workflows.md
@@ -18,7 +18,7 @@ Propagates canonical workflow files from this repository to all configured targe
 ## Execution Context
 
 | Property | Value |
-|----------|
+|----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~10–30 min (scales with number of target repos) |
 | Concurrency | none |

--- a/workflow-docs/version-check.md
+++ b/workflow-docs/version-check.md
@@ -1,0 +1,73 @@
+# `version-check.yml`
+
+## Purpose
+
+Blocks a pull request from merging to `main` if `package.json` contains a prerelease version suffix (e.g. `1.2.3-rc.1`). Ensures only clean semver versions (`X.Y.Z`) reach `main` and are published as the `latest` dist-tag by `publish.yml`.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | branches: `[main]` |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~15 s |
+| Concurrency | none |
+| Permissions | `contents: read` |
+
+---
+
+## Jobs
+
+### `check-version`
+
+**Steps:**
+
+1. `actions/checkout@v4` — checks out source
+2. `Reject prerelease version on main PR` — reads `.version` from `package.json` via `jq`; exits `1` with an actionable message (showing both the current version and the corrected stable version) if a `-` suffix is detected
+
+---
+
+## Required Secrets
+
+None.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `PUBLISH_REPOS` | Receives this file |
+| All service repos (non-`PUBLISH_REPOS`) | **Excluded** — service repos do not publish npm packages and do not use the prerelease guard |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | tag ref `v4` | — |
+
+---
+
+## Known Limitations / Notes
+
+- Companion to `publish.yml` (guards the `main` push trigger) and `release-train.yml` (creates the release PR with the resolved stable version). Together these three form the library release pipeline.
+- Only checks for a prerelease suffix; does not validate that the new version is higher than the previously published version.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(all PUBLISH_REPOS use the canonical version)_ |


### PR DESCRIPTION
## Summary

Six commits addressing three separate concerns, bundled on this branch:

---

### 1. Fix: dynamic Docker image tag (`dockerhub-image-build.yml`)

**Commit:** `fix: derive Docker image tag dynamically from package.json`

- Adds a `Get package version` step that reads `VERSION` from `package.json` via `node -p`.
- Replaces the hardcoded `type=raw,value=2.1.0` tag with `${{ steps.pkg_version.outputs.VERSION }}`.
- Removes `lumberjack` from `SPECIFIC_REPOS` in `sync-workflows.yml` — it builds a standard Docker image and should receive the Docker build workflows.

Fixes #23.

---

### 2. Fix: remove Node.js 16 from CI matrix

**Commit:** `ci: remove Node.js 16 from CI matrix (EOL Sep 2023)`

- Canonical `node.js.yml` updated to `node-version: [20]` only.
- Node 16 reached EOL in September 2023.

---

### 3. Fix: repository_dispatch trigger in rule RC caller stub

**Commit:** `fix: add repository_dispatch trigger to rule RC caller stub`

---

### 4. CI: checkov workaround for Codacy MalformedInputException

**Commit:** `ci: add checkov config to skip github_actions framework`

- Adds `.checkov.yaml` at the repo root to suppress the Codacy CLI crash on multi-line YAML checkov output.

See #38.

---

### 5. Docs: workflow documentation for all 22 canonical workflows

**Commit:** `docs: add workflow-docs per canonical workflow using standard template`

- Adds `workflow-docs/docs-template.md`: standard template for all workflow documentation.
- Adds 9 new docs for workflows added since the original stubs: `branch-target-check`, `dockerhub-image-build-rc`, `package-rule`, `package-rule-rc`, `publish`, `release-train`, `sbom`, `scorecard`, `version-check`.
- Reformats 13 existing stub docs to the new template: `codacy`, `codeql`, `conventional-commits`, `dco-check`, `dependency-review`, `dockerfile-linter`, `dockerhub-image-build`, `gpg-verify`, `milestone`, `njsscan`, `node.js`, `release`, `sync-workflows`.
- `bench.md` and `terraform-security.md` left as-is (no current canonical YAML).

Addresses #35.

---

### 6. Docs: rewrite README

**Commit:** `docs: rewrite README with full SDLC reference and workflow catalogue`

- Repository Classes table mapping every repo to its class.
- Standard PR Check Suite defined once, referenced from all SDLC sections.
- 6 SDLC flows (library repos, service repos, other service repos, tazama-lf rule repos, frmscoe rule repos, canonical workflow changes) — each annotated MANUAL vs AUTO with inline known-issue links.
- Canonical Workflow Reference table (22 rows) with purpose, trigger-in-target-repo, and sync destination.
- Sync Distribution section with all four group definitions and the full REPOS list.
- Routine Maintenance guide covering SHA rotation, Node version updates, manual publish, release-train, milestone/release, Scorecard, sync audits, and frmscoe mirroring.
- Known Issues quick-reference table linked to #28, #36–#40.

Addresses #35.

---

## Related issues

- Fixes #23 (dynamic Docker tag)
- Addresses #35 (README and workflow docs)
- See #28 (service-repo org migration — not fixed here)
- See #36, #37, #38, #39, #40 (known issues documented; fixes in separate issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major expansion of workflow documentation: comprehensive CI/CD spec, standardized workflow template, and detailed docs for checks, publishing, Docker/image pipelines, rule/package release flows, security scans (CodeQL, SBOM, Scorecard), dependency/release automation, sync behavior, and maintenance procedures.
  * README rewritten as the canonical repository specification and PR check/reference guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->