### PR TITLE
fix: migrate all sync targets to tazama-lf org, guard dev branch, scrub stale sync branch

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -126,27 +126,29 @@ jobs:
           in_list() { echo "$2" | grep -Fxq "$1"; }
 
           for repo in $REPOS; do
-            # Library repos (PUBLISH_REPOS) are in tazama-lf org.
-            # Service repos are currently in frmscoe org.
-            # TODO: Migrate all service repos to tazama-lf and update this logic — tracked in tazama-lf/workflows#28
-            if in_list "$repo" "$PUBLISH_REPOS"; then
-              ORG="tazama-lf"
-            else
-              ORG="frmscoe"
-            fi
+            # All target repos are in the tazama-lf org. (Closes #28)
+            ORG="tazama-lf"
 
             git clone https://github.com/$ORG/$repo.git
             cd $repo
             git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/$ORG/$repo.git
 
-            if git ls-remote --heads origin sync-workflows-update | grep sync-workflows-update; then
-              # Branch exists, pull the latest changes
-              git checkout sync-workflows-update
-              git pull origin sync-workflows-update
+            # Ensure dev branch exists in target repo — create from default branch if absent.
+            if ! git ls-remote --heads origin dev | grep -q dev; then
+              DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+              echo "Branch 'dev' not found in $repo; creating from '${DEFAULT_BRANCH}'"
+              git checkout -b dev "origin/${DEFAULT_BRANCH}"
+              git push origin dev
             else
-              # Branch does not exist, create it
-              git checkout -b sync-workflows-update
+              git checkout dev
             fi
+
+            # Always delete and recreate sync-workflows-update to avoid accumulating stale changes.
+            # RESERVED: sync-workflows-update is managed by this workflow — do not use it for regular development contributions.
+            if git ls-remote --heads origin sync-workflows-update | grep -q sync-workflows-update; then
+              git push origin --delete sync-workflows-update || true
+            fi
+            git checkout -b sync-workflows-update
 
             cd ..
             mkdir -p $repo/.github/workflows  # Create the workflows directory if it does not exist

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 
 > **frmscoe rule repos are not in this list.** They are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which syncs to 33 rule repos (`rule-001` through `rule-091`, active subset) via its own `sync-workflows.yml` triggered on `push: dev`.
 
+> ⚠️ **`sync-workflows-update` is a reserved branch name.** This branch is created and managed by `sync-workflows.yml` in every target repo. Do not use this name for regular development contributions — the sync workflow will delete it and recreate it fresh from `dev` on every run. If you have an open `sync-workflows-update` branch in a target repo, be aware it will be force-replaced the next time the workflow runs.
+
 ---
 
 ## Routine Maintenance

--- a/workflow-docs/sync-workflows.md
+++ b/workflow-docs/sync-workflows.md
@@ -36,7 +36,7 @@ Propagates canonical workflow files from this repository to all configured targe
 | `PUBLISH_REPOS` | Library repos that receive `publish.yml`, `version-check.yml`, `release-train.yml` but not `scorecard.yml` |
 | `RULE_REPOS` | `rule-901`, `rule-902` — receive caller stubs for `package-rule*.yml` instead of the full canonical |
 
-**Org routing:** Library repos (`PUBLISH_REPOS`) are cloned from `tazama-lf`; service repos are currently cloned from `frmscoe`. Full service-repo migration is tracked in [workflows#28](https://github.com/tazama-lf/workflows/issues/28).
+**Org routing:** All repos in `REPOS` are cloned from the `tazama-lf` org.
 
 ---
 
@@ -50,7 +50,7 @@ Propagates canonical workflow files from this repository to all configured targe
 2. `Set up Git` — configures git identity for commits
 3. `Install GitHub CLI` — downloads and installs `gh` CLI v2.14.7
 4. `Get PR author details` — captures author name and email for commit attribution
-5. `Sync Workflows to Other Repos` — main loop: clones each repo, checks out or creates `sync-workflows-update` branch, applies per-file sync rules, commits changes, pushes, opens PR
+5. `Sync Workflows to Other Repos` — main loop: clones each repo, ensures `dev` branch exists (creates from default branch if absent), deletes any existing `sync-workflows-update` branch, creates a fresh `sync-workflows-update` from `dev`, applies per-file sync rules, commits changes, pushes, opens PR. **`sync-workflows-update` is a reserved branch name** — do not use it for regular development contributions.
 
 ---
 
@@ -81,9 +81,10 @@ Propagates canonical workflow files from this repository to all configured targe
 
 ## Known Limitations / Notes
 
-- Service repo org URLs still use `frmscoe` (not `tazama-lf`); tracked in [workflows#28](https://github.com/tazama-lf/workflows/issues/28).
 - `gh` CLI is pinned to v2.14.7 via a direct tarball download; should be updated periodically.
 - The workflow fires on all `pull_request` events to `dev`, not just merged ones. This means unmerged PRs trigger sync branches in target repos; reviewers in those repos should not merge `sync-workflows-update` PRs until the source PR is merged.
+- **`sync-workflows-update` is a reserved branch name.** The workflow deletes and recreates it on every run. Do not use this name for regular development contributions; any pushed commits will be discarded on the next sync run.
+- Target repos must have a `dev` branch. If absent, the workflow creates one from the repo’s default branch automatically.
 - `dependabot[bot]` actors are excluded.
 
 ---


### PR DESCRIPTION
## Summary

Fixes #28 and adds two robustness improvements to `sync-workflows.yml`.

### Changes

#### `sync-workflows.yml`

1. **Fix #28 — org routing**: Remove the `if/else` block that incorrectly routed 14 service repos to `frmscoe`. All 26 `REPOS` are in `tazama-lf`. Replace with `ORG="tazama-lf"` unconditionally.

2. **`dev` branch guard**: Before branching, check whether the target repo has a `dev` branch. If absent, create one from the repo's default branch and push it. This prevents the workflow from failing silently against repos that haven't yet had a `dev` branch created.

3. **Stale `sync-workflows-update` scrub**: Replace the previous "pull if exists, create if not" logic with delete-and-recreate:
   - If `sync-workflows-update` exists remotely, delete it.
   - Always create a fresh branch from `dev`.
   - Eliminates stale commit accumulation from previous sync runs.
   - Add `RESERVED` comment warning that the branch name must not be used for regular development contributions.

#### `README.md`

- Add a callout under **Sync Distribution** noting that `sync-workflows-update` is a reserved branch name managed by the workflow, and will be deleted and recreated on every run.

#### `workflow-docs/sync-workflows.md`

- Update org routing note to reflect the fix (remove `frmscoe` reference).
- Update Step 5 description to reflect delete-and-recreate behaviour and the reserved branch warning.
- Update Known Limitations: remove resolved #28 item; add notes on reserved branch name and `dev` branch auto-creation.

---

### Why delete-and-recreate instead of pull-and-update?

Rebasing `sync-workflows-update` on top of prior sync content risks accumulating stale workflow versions or merge conflicts if the target repo's `dev` was force-pushed or rebased. Starting fresh from `dev` is always safe and idempotent.

---

### Impact

- First run after merge: all 14 previously-broken service repos (`relay-service`, `auth-service`, `typology-processor`, `event-director`, `event-sidecar`, `lumberjack`, `nats-utilities`, `batch-ppa`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `Full-Stack-Docker-Tazama`, `rule-executer`, `event-flow`) will receive `sync-workflows-update` PRs for the first time.
- Repos with existing stale `sync-workflows-update` branches will have those branches replaced.
- `GH_TOKEN` is a classic PAT with org scope — confirmed sufficient for all 26 target repos.

Closes #28