### PR TITLE
fix: functional correctness fixes for workflows (items 1-7)

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,6 +16,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   validate-pr-title:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -11,7 +11,10 @@ on: [pull_request]
 
 jobs:
   dco:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'dependabot-preview[bot]' &&
+      github.actor != 'github-actions[bot]'
     # Define the runner environment
     runs-on: ubuntu-latest
     

--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -73,7 +73,8 @@ jobs:
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
       - name: Send Slack Notification
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -78,7 +78,8 @@ jobs:
           push-to-registry: true
 
       - name: Send Slack Notification
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Close Milestone
         run: |
           # Use the environment variables set up earlier to make the API call.
-          curl -X PATCH \
+          curl --fail -s -X PATCH \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer $ACCESS_TOKEN" \
             -d '{"state": "closed"}' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,9 @@ jobs:
       - name: Get Milestone Details
         id: get_milestone
         env:
-          MILESTONE_ID: ${{ github.event.client_payload.milestone_number }}
+          MILESTONE_NUMBER: ${{ github.event.client_payload.milestone_number }}
         run: |
-          MILESTONE_RESPONSE=$(curl --fail -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_ID}")
+          MILESTONE_RESPONSE=$(curl --fail -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_NUMBER}")
           MILESTONE_TITLE=$(echo "$MILESTONE_RESPONSE" | jq -r '.title')
           MILESTONE_DESCRIPTION=$(echo "$MILESTONE_RESPONSE" | jq -r '.description')
           MILESTONE_DATE=$(echo "$MILESTONE_RESPONSE" | jq -r '.due_on')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           PREV_VERSION=$(git describe --abbrev=0 --tags)
           echo "Previous Version: $PREV_VERSION"
           
-          COMMIT_MESSAGES=$(git log $PREV_VERSION^..HEAD --format=%B)
+          COMMIT_MESSAGES=$(git log $PREV_VERSION..HEAD --format=%B)
           echo "Commit Messages: $COMMIT_MESSAGES"
           
           # Determine release type based on commit messages and labels
@@ -100,10 +100,10 @@ jobs:
       # Get the milestone details
       - name: Get Milestone Details
         id: get_milestone
+        env:
+          MILESTONE_ID: ${{ github.event.client_payload.milestone_number }}
         run: |
-          # Retrieve the milestone ID from the workflow input
-          MILESTONE_ID=${{ github.event.client_payload.milestone_number }}
-          MILESTONE_RESPONSE=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_ID}")
+          MILESTONE_RESPONSE=$(curl --fail -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_ID}")
           MILESTONE_TITLE=$(echo "$MILESTONE_RESPONSE" | jq -r '.title')
           MILESTONE_DESCRIPTION=$(echo "$MILESTONE_RESPONSE" | jq -r '.description')
           MILESTONE_DATE=$(echo "$MILESTONE_RESPONSE" | jq -r '.due_on')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ name: Release Workflow
 on:
   repository_dispatch:
     types: [release]
-    properties:
-      milestone_number:
-        type: string
 
 jobs:
   release:

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -27,14 +27,6 @@ jobs:
           git config --global user.email 'github-actions@github.com'
           git config --global credential.helper store
 
-      - name: Install GitHub CLI  # Step to install GitHub CLI for creating pull requests
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl
-          curl -fsSL https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.tar.gz -o ghcli.tar.gz 
-          tar -xzf ghcli.tar.gz
-          sudo cp gh_2.14.7_linux_amd64/bin/gh /usr/local/bin/
-
       - name: Get PR author details  # Step to get the details of the pull request author
         id: pr_author
         env:

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -218,7 +218,7 @@ jobs:
             fi
             cd "$repo"
             git add .github/workflows/
-            git commit -m "ci: sync workflows from central-workflows ${SIGNED_OFF_BY}" || echo "No changes to commit"
+            git commit -m "ci: sync workflows from central-workflows" -m "${SIGNED_OFF_BY}" || echo "No changes to commit"
             git push origin sync-workflows-update || git push origin sync-workflows-update --force
 
             # Clear the GITHUB_TOKEN environment variable and use a temporary file for gh authentication


### PR DESCRIPTION
## Summary

Seven functional correctness fixes identified in the full workflows review, working through the prioritised fix list post-PR #49.

## Changes

### `conventional-commits.yml`  `6ecee13`
- Add `permissions: pull-requests: write` block. The `add_label: 'true'` option calls the GitHub Labels API and returns 403 without this permission.

### `release.yml`  `df011a2`
- Remove invalid `properties: / milestone_number: / type: string` block under `on.repository_dispatch`. This key does not exist in the GHA schema (it belongs to `workflow_dispatch.inputs`) and was silently ignored.

### `sync-workflows.yml` + `dco-check.yml`  `144b43d`
- **sync-workflows.yml:** Split single-message `git commit -m "...${SIGNED_OFF_BY}"` into two `-m` flags so the `Signed-off-by:` trailer appears at the start of a paragraph, satisfying DCO validation.
- **dco-check.yml:** Add `github-actions[bot]` to the actor exclusion in the `if:` condition  automated sync PRs use this identity and cannot carry GPG-signed commits.

### `release.yml`  `c66ba08`
- Fix git log range: `$PREV_VERSION^..HEAD`  `$PREV_VERSION..HEAD` (the `^` caused the previous release commit to be double-counted in changelog generation).
- Move `MILESTONE_ID` from inline shell expansion to step-level `env:` block (injection safety).
- Add `--fail` to the milestone API curl so non-2xx responses surface as failures rather than silent successes.

### `milestone.yml`  `ef4c3df`
- Add `--fail -s` to the `curl -X PATCH` in the Close Milestone step. Without it, a 403/404 exits 0 and the release job proceeds even if the milestone was not closed.

### `sync-workflows.yml`  `a60af6b`
- Remove the `Install GitHub CLI` step that downloaded `gh` v2.14.7 (June 2022) via apt-get and a direct tarball. `ubuntu-latest` runners ship with a current `gh` pre-installed; this step actively downgraded it.

### `dockerhub-image-build.yml` + `dockerhub-image-build-rc.yml`  `69f4350`
- Add `continue-on-error: true` to the `Send Slack Notification` step in both files. A Slack webhook failure (missing secret, Slack outage) was failing the entire build job after a successful image push.

## Testing
All changes are configuration/script fixes with no behaviour change under normal operation. Abnormal-path behaviour (missing secrets, failed API calls) is improved by the `--fail` and `continue-on-error` additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened workflow permissions and release commit range handling for more predictable CI behavior.
  * Made notification and API steps fail on HTTP errors while preventing notification failures from blocking jobs.
  * Streamlined workflow sync and milestone handling to improve release and automation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->