### PR TITLE
fix: address audit items 1, 3-15 from full-workflows-review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
   analyze:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     name: Analyze
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -46,7 +46,7 @@ jobs:
         # Loop through each commit and check for the Signed-off-by line
         for commit in $commits; do
           # Check if the commit message contains the Signed-off-by line
-          if ! git show --quiet --format=%B $commit | grep -q "^Signed-off-by: "; then
+          if ! git show --quiet --format=%B "$commit" | grep -q "^Signed-off-by: "; then
             # If not, add the commit hash to the list of non-compliant commits
             non_compliant_commits="$non_compliant_commits $commit"
           fi

--- a/.github/workflows/gpg-verify.yml
+++ b/.github/workflows/gpg-verify.yml
@@ -44,11 +44,18 @@ jobs:
 
         # Check the GPG verification status of each commit via the GitHub commit API
         for commit in $commits; do
-          verified=$(curl -s --max-time 10 \
+          response=$(curl -s --max-time 10 --fail \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit \
-            | jq -r '.commit.verification.verified')
+            https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit)
+          curl_exit=$?
+
+          if [[ $curl_exit -ne 0 ]]; then
+            echo "GitHub API request failed for commit $commit (curl exit $curl_exit). Check network or API availability."
+            exit 1
+          fi
+
+          verified=$(echo "$response" | jq -r '.commit.verification.verified')
 
           # If the commit is not verified, list it and exit with a non-zero status
           if [[ "$verified" != "true" ]]; then

--- a/.github/workflows/gpg-verify.yml
+++ b/.github/workflows/gpg-verify.yml
@@ -44,7 +44,7 @@ jobs:
 
         # Check the GPG verification status of each commit via the GitHub commit API
         for commit in $commits; do
-          verified=$(curl -s \
+          verified=$(curl -s --max-time 10 \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit \

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -21,20 +21,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Step to check out the repository code.
-      - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4 (upgraded from v2)
-
-      # Step to set up environment variables required for the script.
-      - name: Set up environment variables
-        run: |
-          # Set the GitHub token for authentication.
-          echo "ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-          # Set the milestone number based on the workflow input.
-          echo "MILESTONE_NUMBER=${{ github.event.inputs.milestoneId }}" >> $GITHUB_ENV
-          # Set the base API URL for GitHub.
-          echo "API_URL=https://api.github.com" >> $GITHUB_ENV
-
       # Step to close the specified milestone using GitHub API.
       - name: Close Milestone
         run: |

--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -38,10 +38,12 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: nodejsscan scan
       id: njsscan
+      continue-on-error: true
       uses: ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81
       with:
-        args: '. --sarif --output results.sarif || true'
+        args: '. --sarif --output results.sarif'
     - name: Upload njsscan report
       uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+      if: hashFiles('results.sarif') != ''
       with:
         sarif_file: results.sarif

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -80,8 +80,11 @@ jobs:
 
       - name: Clone Rule Executer repository (dev branch)
         run: |
+          git config --global url."https://x-access-token:${GH_TOKEN_LIB}@github.com/".insteadOf "https://github.com/"
           git clone https://github.com/tazama-lf/rule-executer -b dev rule-executer
           echo "Rule Executer clone complete."
+        env:
+          GH_TOKEN_LIB: ${{ secrets.GH_TOKEN_LIB }}
 
       - name: Prepare rule-executer-${{ inputs.rule_number }}
         run: |

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -83,8 +83,11 @@ jobs:
 
       - name: Clone Rule Executer repository (main branch)
         run: |
+          git config --global url."https://x-access-token:${GH_TOKEN_LIB}@github.com/".insteadOf "https://github.com/"
           git clone https://github.com/tazama-lf/rule-executer -b main rule-executer
           echo "Rule Executer clone complete."
+        env:
+          GH_TOKEN_LIB: ${{ secrets.GH_TOKEN_LIB }}
 
       - name: Prepare rule-executer-${{ inputs.rule_number }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,10 +69,11 @@ jobs:
 
       # Send Slack notification — requires SLACK_WEBHOOK_URL org/repo secret
       - name: Send Slack notification
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl -s -X POST -H 'Content-type: application/json' --data '{
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{
             "blocks": [
               {
                 "type": "header",
@@ -96,4 +97,4 @@ jobs:
                 ]
               }
             ]
-          }' "$SLACK_WEBHOOK_URL" || true
+          }' "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -237,6 +237,7 @@ jobs:
       - name: Open PR to main
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
         run: |
           VERSION="$VERSION_INPUT"
           BRANCH="${{ steps.push_branch.outputs.branch }}"
@@ -250,7 +251,7 @@ jobs:
             --body-file /tmp/pr-body.md \
             --base main \
             --head "$BRANCH" \
-            --reviewer "${{ secrets.GH_USERNAME }}"; then
+            --reviewer "$GH_USERNAME"; then
             EXISTING=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number // empty')
             if [ -n "$EXISTING" ]; then
               echo "PR #${EXISTING} already exists for $BRANCH — skipping."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,6 @@ jobs:
             RELEASE_TYPE="major"
           elif echo "$COMMIT_MESSAGES" | grep -q -e "feat:"; then
             RELEASE_TYPE="minor"
-          elif echo "$COMMIT_MESSAGES" | grep -q -e "feat:" && (echo "$COMMIT_MESSAGES" | grep -q -e "fix:" || echo "$COMMIT_MESSAGES" | grep -q -e "enhancement:" || echo "$COMMIT_MESSAGES" | grep -q -e "docs:" || echo "$COMMIT_MESSAGES" | grep -q -e "refactor:" || echo "$COMMIT_MESSAGES" | grep -q -e "chore:"); then
-            RELEASE_TYPE="minor"
           elif echo "$COMMIT_MESSAGES" | grep -q -e "fix:" -e "enhancement:" -e "docs:" -e "refactor:" -e "chore:" -e "build:" -e "ci:" -e "perf:" -e "style:" -e "test:" -e "chore(deps):" -e "chore(deps-dev):"; then
             RELEASE_TYPE="patch"
           fi

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -35,8 +35,10 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Build the Docker image
+      if: hashFiles('Dockerfile') != ''
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest
     - name: Scan the image and upload dependency results
+      if: hashFiles('Dockerfile') != ''
       uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
       with:
         image: "localbuild/testimage:latest"

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -160,7 +160,7 @@ jobs:
               if in_list "$repo" "$RULE_REPOS" && [[ "${filename}" == package-rule*.yml ]]; then
                 continue
               fi
-              # scorecard.yml: only copy to service repos â€" skip library/npm repos and rule repos
+              # scorecard.yml: only copy to service repos — skip library/npm repos and rule repos
               if [[ "${filename}" == "scorecard.yml" ]] && in_list "$repo" "$PUBLISH_REPOS"; then
                 continue
               fi

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -213,11 +213,6 @@ jobs:
             git commit -m "ci: sync workflows from central-workflows" -m "${SIGNED_OFF_BY}" || echo "No changes to commit"
             git push origin sync-workflows-update || git push origin sync-workflows-update --force
 
-            # Clear the GITHUB_TOKEN environment variable and use a temporary file for gh authentication
-            echo "${{ secrets.GH_TOKEN }}" > /tmp/gh_token
-            unset GITHUB_TOKEN
-            gh auth login --with-token < /tmp/gh_token
-
             # Create the PR with reviewers
             IFS=',' read -ra REVIEWERS <<< "${PR_REVIEWERS}"
             REVIEWERS_ARGS=""
@@ -226,9 +221,6 @@ jobs:
             done
 
             gh pr create --title "ci: sync workflows from central-workflows" --body "This PR syncs workflows from the central-workflows repository. ${SIGNED_OFF_BY}" --base dev --head sync-workflows-update $REVIEWERS_ARGS || echo "PR already exists, updating existing PR"
-
-            # Cleanup
-            rm /tmp/gh_token
 
             cd ..
           done

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -30,7 +30,15 @@ jobs:
 
       - name: Reject prerelease version on main PR
         run: |
-          VERSION=$(jq -r '.version' package.json)
+          if [ ! -f package.json ]; then
+            echo "❌ package.json not found"
+            exit 1
+          fi
+          VERSION=$(jq -r '.version // empty' package.json)
+          if [ -z "$VERSION" ]; then
+            echo "❌ No version field in package.json"
+            exit 1
+          fi
           if [[ "$VERSION" == *-* ]]; then
             echo "❌ package.json version '$VERSION' contains a prerelease suffix."
             echo "   Strip the suffix (e.g. change '$VERSION' → '${VERSION%-*}') before merging to main."

--- a/workflow-docs/release-train.md
+++ b/workflow-docs/release-train.md
@@ -49,7 +49,7 @@ Prepares a library release PR from `dev` → `main`. Given a target stable versi
 
 | Secret | Scope | Purpose |
 |--------|-------|---------|
-| `GH_TOKEN_LIB` | org | API commits, npm install auth, PR creation |
+| `GH_TOKEN_LIB` | org | API commits, npm install auth, PR creation — classic PAT requires `repo`, `workflow`, `read:packages` |
 
 ---
 
@@ -76,6 +76,7 @@ Prepares a library release PR from `dev` → `main`. Given a target stable versi
 - `checkov:skip=CKV_GHA_7` annotation suppresses a false-positive: the `version` input controls only the release branch name and `package.json` version — not the build artifact source.
 - If `release/v<N>` already exists it is force-reset to the current `dev` HEAD, enabling idempotent reruns without manual cleanup.
 - The PR body does not include an auto-generated changelog; reviewers should compare `dev` to `main` manually before approving.
+- **`GH_TOKEN_LIB` required scopes (classic PAT):** `repo` (covers creating commits via the GitHub REST API, creating/resetting the `release/v<N>` branch, and opening the PR to main — equivalent to `contents: write` + `pull-requests: write` in fine-grained token terms), `workflow` (required when any commit touches `.github/workflows/` files), and `read:packages` (npm install from GitHub Packages). Commits created via the GitHub API with a token bearing the `repo` scope are automatically marked **Verified** by GitHub — no GPG signing key is needed on the runner.
 
 ---
 


### PR DESCRIPTION
﻿## Summary

Addresses items 1 and 315 from the `full-workflows-review.md` audit. Item 2 (`dockerhub-image-build{,-rc}.yml` BuildKit secret) is deferred pending Dockerfile changes in each service repo.

## Changes

###  Major fixes

- **`njsscan.yml`**: Replace `|| true` with `continue-on-error: true` on the scan step; add `if: hashFiles('results.sarif') != ''` guard on the upload step so a scanner failure surfaces a real error rather than a confusing "file not found"

###  Minor fixes

- **`milestone.yml`**: Remove unused `actions/checkout` step and the redundant `echo "ACCESS_TOKEN=..." >> $GITHUB_ENV` line (the `env:` block on the Close Milestone step already sets it)
- **`package-rule.yml` + `package-rule-rc.yml`**: Add `GH_TOKEN_LIB` authentication to the `rule-executer` git clone so it works for private repos
- **`version-check.yml`**: Add guards for missing `package.json` and missing/null `version` field
- **`gpg-verify.yml`**: Add `--max-time 10` to the curl call in the commit verification loop
- **`release-train.yml`**: Move `${{ secrets.GH_USERNAME }}` from inline `run:` expression to an `env:` block (`PR_REVIEWER`)
- **`sync-workflows.yml`**: Replace the `/tmp/gh_token` file write/read/cleanup pattern with the `GITHUB_TOKEN` env var (already set in the step's `env:` block  `gh` picks it up automatically)
- **`sync-workflows.yml`**: Fix garbled UTF-8 em-dash (`â"`  ``) in the scorecard.yml exclusion comment
- **`publish.yml`**: Replace `|| true` on the Slack curl step with `continue-on-error: true`; add `--fail -sS` so HTTP 4xx/5xx errors are visible (consistent with the same fix applied to `dockerhub-image-build{,-rc}.yml` in PR #50)
- **`dco-check.yml`**: Quote `$commit`  `"$commit"` in the `git show` command
- **`sbom.yml`**: Add `if: hashFiles('Dockerfile') != ''` to the Docker build and SBOM scan steps so repos without a Dockerfile at root skip gracefully rather than failing

### ℹ Dead code removal

- **`release.yml`**: Remove unreachable `elif` branch in `Determine Release Type`  the `feat: AND fix:` condition can never be reached because the preceding `elif` already matches on `feat:` alone
- **`codeql.yml`**: Simplify `runs-on` from the swift/ubuntu ternary expression to plain `ubuntu-latest`  the matrix only contains `javascript`, so the swift branch is never selected

###  Documentation

- **`workflow-docs/release-train.md`**: Document the required classic PAT scopes for `GH_TOKEN_LIB` (`repo`, `workflow`, `read:packages`) in the secrets table and Known Limitations section; note that GitHub API commits with `repo` scope are automatically marked Verified

## Deferred

- **Item 2  `dockerhub-image-build{,-rc}.yml`**: Move `GH_TOKEN` from `build-args` to a BuildKit secret. Requires corresponding `RUN --mount=type=secret,id=GH_TOKEN` changes in every service repo Dockerfile. Tracked separately.

## Testing

All changes are in workflow YAML or documentation files. No runtime behaviour changes are expected for repos that are already in their intended state (Docker-enabled service repos with Dockerfiles, library repos with `package.json`). The dead-code removals and guard additions are logic-safe: the removed branches were unreachable, and the added `if:` guards replicate the existing implicit assumptions explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability with stricter timeouts, error handling, and continue-on-error safeguards
  * Standardized runner selection and conditional execution for build/scan steps
  * Hardened commit and signature verification checks and DCO handling
  * Switched repository cloning to token-based authenticated fetches and simplified release PR reviewer sourcing
  * Adjusted notification behavior to avoid failing builds on delivery issues

* **Documentation**
  * Clarified secret/token requirements and usage for release workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->