### PR TITLE
fix: use BuildKit secret for GH_TOKEN in Docker build workflows

### DIFF
--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -63,7 +63,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -68,7 +68,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32


### PR DESCRIPTION
Switches both `dockerhub-image-build.yml` and `dockerhub-image-build-rc.yml`
from `build-args: GH_TOKEN` to `secrets: GH_TOKEN` (BuildKit secrets mechanism).

**MERGE THIS LAST** - after all 11 service repo Dockerfile PRs are merged.
Merging this first would pass `GH_TOKEN` via `secrets:` but no Dockerfile would
have `--mount=type=secret` to consume it, causing `npm ci` to fail with 401.

Closes #52.