### PR TITLE
fix: fire sync on push to dev and handle non-PR triggers

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -11,6 +11,10 @@ on:
     branches: [ "dev" ]  # Fires only when commits land on dev (i.e. a PR merges or a direct push). Fixes #36.
   workflow_dispatch:
 
+concurrency:
+  group: sync-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Sync_All_Repos_Common_Workflows:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -35,11 +39,13 @@ jobs:
           # For pull_request events use the PR author login; for push/workflow_dispatch fall back to the triggering actor.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PR_AUTHOR_NAME=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.user.login')
+            PR_AUTHOR_NAME_FULL=$(git log -1 --pretty=format:'%an')
+            PR_AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
           else
             PR_AUTHOR_NAME="${{ github.actor }}"
+            PR_AUTHOR_NAME_FULL="${{ github.actor }}"
+            PR_AUTHOR_EMAIL="${{ github.actor }}@users.noreply.github.com"
           fi
-          PR_AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
-          PR_AUTHOR_NAME_FULL=$(git log -1 --pretty=format:'%an')
           echo "PR_AUTHOR_NAME=${PR_AUTHOR_NAME}" >> $GITHUB_ENV
           echo "PR_AUTHOR_EMAIL=${PR_AUTHOR_EMAIL}" >> $GITHUB_ENV
           echo "PR_AUTHOR_NAME_FULL=${PR_AUTHOR_NAME_FULL}" >> $GITHUB_ENV

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This GitHub Actions workflow syncs workflows from a central repository to other repositories when a pull request is merged.
+# This GitHub Actions workflow syncs workflows from a central repository to other repositories when changes are pushed to dev.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
 name: Sync Workflows
 
 on:
-  pull_request:
-    branches: [ "dev" ] # The branches below must be a subset of the branches above
+  push:
+    branches: [ "dev" ]  # Fires only when commits land on dev (i.e. a PR merges or a direct push). Fixes #36.
   workflow_dispatch:
 
 jobs:
@@ -27,12 +27,17 @@ jobs:
           git config --global user.email 'github-actions@github.com'
           git config --global credential.helper store
 
-      - name: Get PR author details  # Step to get the details of the pull request author
+      - name: Get actor details  # Step to get the triggering actor's details for the Signed-off-by line
         id: pr_author
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_AUTHOR_NAME=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.user.login')
+          # For pull_request events use the PR author login; for push/workflow_dispatch fall back to the triggering actor.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_AUTHOR_NAME=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.user.login')
+          else
+            PR_AUTHOR_NAME="${{ github.actor }}"
+          fi
           PR_AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
           PR_AUTHOR_NAME_FULL=$(git log -1 --pretty=format:'%an')
           echo "PR_AUTHOR_NAME=${PR_AUTHOR_NAME}" >> $GITHUB_ENV

--- a/workflow-docs/sync-workflows.md
+++ b/workflow-docs/sync-workflows.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Propagates canonical workflow files from this repository to all configured target repos. When a PR to `dev` is opened or updated, it clones each target repo, copies the applicable workflow files according to per-file sync rules, and opens a `sync-workflows-update` PR in each target repo. `sync-workflows.yml` and `node.js.yml` are explicitly excluded from the bundle.
+Propagates canonical workflow files from this repository to all configured target repos. When commits land on `dev` (i.e. a PR is merged or a direct push is made), it clones each target repo, copies the applicable workflow files according to per-file sync rules, and opens a `sync-workflows-update` PR in each target repo. `sync-workflows.yml` and `node.js.yml` are explicitly excluded from the bundle.
 
 ---
 
@@ -10,7 +10,7 @@ Propagates canonical workflow files from this repository to all configured targe
 
 | Event | Conditions |
 |-------|-----------|
-| `pull_request` | branches: `[dev]` (fires on open, update, and close) |
+| `push` | branches: `[dev]` (fires only when commits land on `dev`) |
 | `workflow_dispatch` | manual |
 
 ---
@@ -21,7 +21,7 @@ Propagates canonical workflow files from this repository to all configured targe
 |----------|-------|
 | Runner | `ubuntu-latest` |
 | Typical duration | ~10–30 min (scales with number of target repos) |
-| Concurrency | none |
+| Concurrency | `group: sync-workflows-${{ github.ref }}`, cancel-in-progress |
 | Permissions | default (plus `GH_TOKEN` for cross-repo operations) |
 
 ---
@@ -48,9 +48,8 @@ Propagates canonical workflow files from this repository to all configured targe
 
 1. `actions/checkout@v4` — checks out this workflows repo
 2. `Set up Git` — configures git identity for commits
-3. `Install GitHub CLI` — downloads and installs `gh` CLI v2.14.7
-4. `Get PR author details` — captures author name and email for commit attribution
-5. `Sync Workflows to Other Repos` — main loop: clones each repo, ensures `dev` branch exists (creates from default branch if absent), deletes any existing `sync-workflows-update` branch, creates a fresh `sync-workflows-update` from `dev`, applies per-file sync rules, commits changes, pushes, opens PR. **`sync-workflows-update` is a reserved branch name** — do not use it for regular development contributions.
+3. `Get actor details` — captures the triggering actor's name and email for commit attribution; uses the PR author for `pull_request` events and `github.actor` for `push`/`workflow_dispatch` events
+4. `Sync Workflows to Other Repos` — main loop: clones each repo, ensures `dev` branch exists (creates from default branch if absent), deletes any existing `sync-workflows-update` branch, creates a fresh `sync-workflows-update` from `dev`, applies per-file sync rules, commits changes, pushes, opens PR. **`sync-workflows-update` is a reserved branch name** — do not use it for regular development contributions.
 
 ---
 
@@ -81,8 +80,7 @@ Propagates canonical workflow files from this repository to all configured targe
 
 ## Known Limitations / Notes
 
-- `gh` CLI is pinned to v2.14.7 via a direct tarball download; should be updated periodically.
-- The workflow fires on all `pull_request` events to `dev`, not just merged ones. This means unmerged PRs trigger sync branches in target repos; reviewers in those repos should not merge `sync-workflows-update` PRs until the source PR is merged.
+- The workflow fires on `push` to `dev`, so it only runs when commits actually land on the branch (typically after a PR merge). `sync-workflows-update` PRs in target repos should be safe to review and merge as soon as they appear.
 - **`sync-workflows-update` is a reserved branch name.** The workflow deletes and recreates it on every run. Do not use this name for regular development contributions; any pushed commits will be discarded on the next sync run.
 - Target repos must have a `dev` branch. If absent, the workflow creates one from the repo’s default branch automatically.
 - `dependabot[bot]` actors are excluded.


### PR DESCRIPTION
## Summary

Fixes two bugs in `sync-workflows.yml` that prevented it from running correctly.

### Fix 1: Trigger on push, not pull_request (closes #36)

`sync-workflows.yml` was triggered on `pull_request: branches: [dev]`, which fires when a PR is **opened or updated** against `dev` — not when it is **merged**. This meant the sync would run against the PR branch (before it lands on `dev`) and not on the post-merge commit.

Changed to `push: branches: [dev]` so the sync fires only when commits actually land on `dev`.

### Fix 2: Handle non-PR triggers gracefully

The "Get PR author details" step unconditionally called `gh api .../pulls/${{ github.event.pull_request.number }}`, which is `null` for `workflow_dispatch` and `push` events. This caused the `gh api` call to fail with a 404.

Added a conditional check: for `pull_request` events, use the PR API to get the author; for `push` and `workflow_dispatch`, fall back to `${{ github.actor }}`.

## Changes

- `sync-workflows.yml`: trigger `pull_request → push: branches: [dev]`
- `sync-workflows.yml`: rename step to "Get actor details"; guard `gh api` call with `github.event_name` check

## Testing

`workflow_dispatch` can be used to test after merge without waiting for a push to `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow updated to run on commits to the dev branch (and manual runs), preventing duplicate concurrent runs via concurrency control.
  * Improved attribution logic so actions and commits record clearer actor identity across push and manual runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->