### PR TITLE
fix: replace npm ci with npm install in package-rule workflows

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
-          npm ci
+          npm install
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
-          npm ci
+          npm install
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 


### PR DESCRIPTION
## Summary

The canonical reusable workflows (`package-rule.yml` and `package-rule-rc.yml`) clone `rule-executer` then use `sed` to rewrite the rule dependency in `package.json` at runtime. The cloned repo contains a `package-lock.json`. `npm ci` then fails because the lockfile no longer matches the modified `package.json`.

This was broken from day one - the canonical reusable workflow has never successfully run a packaging job where the rule dependency version or scope needed to change.

## Root cause

`npm ci` requires the lockfile to exactly match `package.json`. The `sed` rewrite always invalidates that match.

## Fix

Replace `npm ci` with `npm install` in the `Install dependencies` step of both files. This matches the approach used in the original hand-written per-repo workflow in `rule-executer` before the canonical reusable approach was introduced.

## Files changed

- `.github/workflows/package-rule.yml` - `npm ci` -> `npm install`
- `.github/workflows/package-rule-rc.yml` - `npm ci` -> `npm install`

Closes #56 (partial)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation configuration in build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->