### PR TITLE
fix: guard against empty MILESTONE_NUMBER in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,10 @@ jobs:
         env:
           MILESTONE_NUMBER: ${{ github.event.client_payload.milestone_number }}
         run: |
+          if [[ -z "$MILESTONE_NUMBER" ]]; then
+            echo "::error::MILESTONE_NUMBER is not set in client_payload"
+            exit 1
+          fi
           MILESTONE_RESPONSE=$(curl --fail -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_NUMBER}")
           MILESTONE_TITLE=$(echo "$MILESTONE_RESPONSE" | jq -r '.title')
           MILESTONE_DESCRIPTION=$(echo "$MILESTONE_RESPONSE" | jq -r '.description')


### PR DESCRIPTION
﻿## Summary

If `repository_dispatch` fires without `milestone_number` in `client_payload`, `MILESTONE_NUMBER` is empty. The curl URL becomes `.../milestones/` (no ID), which the GitHub API answers with a **200 array** rather than a 404 - so `--fail` does not trigger. `jq -r '.title'` on an array returns `null`, which flows silently into the release notes with no indication anything went wrong.

## Fix

Add an explicit empty-check before the `curl` call:

```bash
if [[ -z "$MILESTONE_NUMBER" ]]; then
  echo "::error::MILESTONE_NUMBER is not set in client_payload"
  exit 1
fi
```

This makes the job fail immediately at the source with a clear, actionable error message rather than silently producing a release with `null` metadata.

Partially addresses #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow robustness by adding validation for required release parameters, preventing potential errors during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->