### PR TITLE
fix: address CodeRabbit findings from sync PRs (issue #56)

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -104,14 +104,22 @@ jobs:
           #   "rule": "npm:@tazama-lf/rule-901@X.Y.Z"
           #   → for tazama-lf: keep @tazama-lf, change rule number and version
           #   → for frmscoe:   switch namespace to @frmscoe, change rule number and version
-          if [ "$RULE_ORG" = "frmscoe" ]; then
-            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@frmscoe/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
-          else
-            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@tazama-lf/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
-          fi
+          case "$RULE_ORG" in
+            frmscoe)
+              EXPECTED_SCOPE="@frmscoe"
+              sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@frmscoe/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+              ;;
+            tazama-lf)
+              EXPECTED_SCOPE="@tazama-lf"
+              sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@tazama-lf/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+              ;;
+            *)
+              echo "::error::Unknown RULE_ORG value: '${RULE_ORG}'. Expected 'frmscoe' or 'tazama-lf'."
+              exit 1
+              ;;
+          esac
 
           # Validate rule dependency rewrite succeeded — fail if pattern didn't match
-          EXPECTED_SCOPE=$( [ "$RULE_ORG" = "frmscoe" ] && echo "@frmscoe" || echo "@tazama-lf" )
           if ! grep -q "npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}" "${RULE_DIR}/package.json"; then
             echo "❌ Failed to update rule dependency in package.json — pattern may have changed"
             echo "   Expected: npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}"

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
-          npm ci
+          npm install
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
-          npm ci
+          npm install
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -104,14 +104,22 @@ jobs:
           echo "Applying substitutions for rule-${RULE_NUM} (org: ${RULE_ORG}, version: ${VERSION})"
 
           # Update rule dependency in package.json
-          if [ "$RULE_ORG" = "frmscoe" ]; then
-            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@frmscoe/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
-          else
-            sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@tazama-lf/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
-          fi
+          case "$RULE_ORG" in
+            frmscoe)
+              EXPECTED_SCOPE="@frmscoe"
+              sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@frmscoe/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+              ;;
+            tazama-lf)
+              EXPECTED_SCOPE="@tazama-lf"
+              sed -i "s|npm:@tazama-lf/rule-[^@]*@[^\"]*|npm:@tazama-lf/rule-${RULE_NUM}@${VERSION}|g" "${RULE_DIR}/package.json"
+              ;;
+            *)
+              echo "::error::Unknown RULE_ORG value: '${RULE_ORG}'. Expected 'frmscoe' or 'tazama-lf'."
+              exit 1
+              ;;
+          esac
 
           # Validate rule dependency rewrite succeeded — fail if pattern didn't match
-          EXPECTED_SCOPE=$( [ "$RULE_ORG" = "frmscoe" ] && echo "@frmscoe" || echo "@tazama-lf" )
           if ! grep -q "npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}" "${RULE_DIR}/package.json"; then
             echo "❌ Failed to update rule dependency in package.json — pattern may have changed"
             echo "   Expected: npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,25 +20,6 @@ jobs:
           ref: main
           fetch-depth: 0 # Fetch all tags
 
-      # Fetch merged pull request and determine release labels
-      - uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9  # v1
-        id: get-merged-pull-request
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions-ecosystem/action-release-label@1c7ef83d383a57bf253a2e2e9dfe1b55f445ae15  # v1
-        id: release-label
-        if: ${{ steps.get-merged-pull-request.outputs.title != null }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Get the latest tag in the repository
-      - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435  # v1
-        id: get-latest-tag
-        if: ${{ steps.release-label.outputs.level != null }}
-        with:
-          semver_only: true
-        
       # Determine the release type (major, minor, patch) based on commit messages  
       - name: Determine Release Type
         id: determine_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,11 @@ jobs:
       - name: Determine Release Type
         id: determine_release
         run: |
-          PREV_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
-          echo "Previous Version: $PREV_VERSION"
-          
-          COMMIT_MESSAGES=$(git log $PREV_VERSION..HEAD --format=%B)
+          PREV_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo "")
+          echo "Previous Version: ${PREV_VERSION:-none (first release)}"
+          GIT_LOG_RANGE="${PREV_VERSION:+${PREV_VERSION}..}HEAD"
+
+          COMMIT_MESSAGES=$(git log $GIT_LOG_RANGE --format=%B)
           echo "Commit Messages: $COMMIT_MESSAGES"
           
           # Determine release type based on commit messages and labels
@@ -121,8 +122,9 @@ jobs:
           LABEL_DEPS="chore(deps):"
           LABEL_DEPS_DEV="chore(deps-dev):"
           # Get the last release tag
-          LAST_RELEASE_TAG=$(git describe --abbrev=0 --tags)
-          echo "Last Release Tag: $LAST_RELEASE_TAG"
+          LAST_RELEASE_TAG=$(git describe --abbrev=0 --tags 2>/dev/null || echo "")
+          GIT_LOG_RANGE="${LAST_RELEASE_TAG:+${LAST_RELEASE_TAG}..}HEAD"
+          echo "Last Release Tag: ${LAST_RELEASE_TAG:-none (first release)}"
           # Get the milestone details from the output of the previous step
           MILESTONE_TITLE="${{ steps.get_milestone.outputs.milestone_title }}"
           MILESTONE_DESCRIPTION="${{ steps.get_milestone.outputs.milestone_description }}"
@@ -138,7 +140,7 @@ jobs:
             local section_label="$2"
             local section_icon="$3"
             # Get the commit messages with the specified label between the last release and the current release
-            local commit_messages=$(git log --pretty=format:"- %s (Linked Issues: %C(yellow)%H%Creset)" "$LAST_RELEASE_TAG..HEAD" --grep="$section_label" --no-merges --decorate --decorate-refs=refs/issues)
+            local commit_messages=$(git log --pretty=format:"- %s (Linked Issues: %C(yellow)%H%Creset)" $GIT_LOG_RANGE --grep="$section_label" --no-merges --decorate --decorate-refs=refs/issues)
             # If there are commit messages, append the section to the changelog file
             if [ -n "$commit_messages" ]; then
               # Remove duplicate commit messages
@@ -169,7 +171,7 @@ jobs:
           # Function to append non-labeled commits to the changelog file
           append_non_labeled_commits() {
             # Get the commit messages that do not match any conventional commit labels between the last release and the current release
-            local non_labeled_commit_messages=$(git log --pretty=format:"- %s (Linked Issues: %C(yellow)%H%Creset)" "$LAST_RELEASE_TAG..HEAD" --invert-grep --grep="^fix:\|^feat:\|^enhancement:\|^docs:\|^refactor:\|^chore:\|^build:\|^ci:\|^perf:\|^style:\|^test:\|^BREAKING CHANGE:\|^feat!:\|^chore(deps):\|^chore(deps-dev):")
+            local non_labeled_commit_messages=$(git log --pretty=format:"- %s (Linked Issues: %C(yellow)%H%Creset)" $GIT_LOG_RANGE --invert-grep --grep="^fix:\|^feat:\|^enhancement:\|^docs:\|^refactor:\|^chore:\|^build:\|^ci:\|^perf:\|^style:\|^test:\|^BREAKING CHANGE:\|^feat!:\|^chore(deps):\|^chore(deps-dev):")
             # If there are non-labeled commit messages, append the section to the changelog file
             if [ -n "$non_labeled_commit_messages" ]; then
               # Remove duplicate commit messages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Determine Release Type
         id: determine_release
         run: |
-          PREV_VERSION=$(git describe --abbrev=0 --tags)
+          PREV_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
           echo "Previous Version: $PREV_VERSION"
           
           COMMIT_MESSAGES=$(git log $PREV_VERSION..HEAD --format=%B)
@@ -69,7 +69,7 @@ jobs:
       - name: Bump Version
         id: bump_version
         run: |
-          PREV_VERSION=$(git describe --abbrev=0 --tags)
+          PREV_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
           echo "Previous Version: $PREV_VERSION"
           
           RELEASE_TYPE=${{ steps.determine_release.outputs.release_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,10 @@ jobs:
         env:
           MILESTONE_NUMBER: ${{ github.event.client_payload.milestone_number }}
         run: |
+          if [[ -z "$MILESTONE_NUMBER" ]]; then
+            echo "::error::MILESTONE_NUMBER is not set in client_payload"
+            exit 1
+          fi
           MILESTONE_RESPONSE=$(curl --fail -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_NUMBER}")
           MILESTONE_TITLE=$(echo "$MILESTONE_RESPONSE" | jq -r '.title')
           MILESTONE_DESCRIPTION=$(echo "$MILESTONE_RESPONSE" | jq -r '.description')

--- a/workflow-docs/package-rule-rc.md
+++ b/workflow-docs/package-rule-rc.md
@@ -48,8 +48,8 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 3. `Read rule version from package.json` — reads `version`; fails if version is NOT a prerelease (`-` suffix required — guards against RC build running on a stable version)
 4. `Clone Rule Executer repository (dev branch)` — clones `tazama-lf/rule-executer@dev`
 5. `Prepare rule-executer-<N>` — copies cloned directory
-6. `Modify package.json and Dockerfile for rule <N>` — patches rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
-7. `Install dependencies` — `npm ci` in the patched directory
+6. `Modify package.json and Dockerfile for rule <N>` — uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
+7. `Install dependencies` — `npm install` in the patched directory (uses `npm install` rather than `npm ci` because the preceding `sed` step modifies `package.json`, invalidating the lockfile)
 8. `Build and push RC Docker image` — builds once; tags with `VERSION` and `:rc`; pushes both
 9. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
 
@@ -59,7 +59,7 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 
 | Secret | Scope | Purpose |
 |--------|-------|---------|
-| `GH_TOKEN_LIB` | org | `npm ci` for private packages; checkout token |
+| `GH_TOKEN_LIB` | org | `npm install` for private packages; checkout token |
 | `DOCKER_USERNAME` | org | Docker Hub login |
 | `DOCKER_PASSWORD` | org | Docker Hub password |
 | `SLACK_WEBHOOK_URL` | org | Slack notification |

--- a/workflow-docs/package-rule.md
+++ b/workflow-docs/package-rule.md
@@ -48,8 +48,8 @@ Called from a caller stub `package-rule.yml` in each rule repo rather than being
 3. `Read rule version from package.json` — reads `version`; fails if version is a prerelease (guards against stable build running on a prerelease version)
 4. `Clone Rule Executer repository (main branch)` — clones `tazama-lf/rule-executer@main`
 5. `Prepare rule-executer-<N>` — copies cloned directory
-6. `Modify package.json and Dockerfile for rule <N>` — patches rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
-7. `Install dependencies` — `npm ci` in the patched directory
+6. `Modify package.json and Dockerfile for rule <N>` — uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
+7. `Install dependencies` — `npm install` in the patched directory (uses `npm install` rather than `npm ci` because the preceding `sed` step modifies `package.json`, invalidating the lockfile)
 8. `Build and push stable Docker image` — builds once; tags with `VERSION` and `:latest`; pushes both
 9. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
 
@@ -59,7 +59,7 @@ Called from a caller stub `package-rule.yml` in each rule repo rather than being
 
 | Secret | Scope | Purpose |
 |--------|-------|---------|
-| `GH_TOKEN_LIB` | org | `npm ci` for private packages; checkout token |
+| `GH_TOKEN_LIB` | org | `npm install` for private packages; checkout token |
 | `DOCKER_USERNAME` | org | Docker Hub login |
 | `DOCKER_PASSWORD` | org | Docker Hub password |
 | `SLACK_WEBHOOK_URL` | org | Slack notification |

--- a/workflow-docs/release.md
+++ b/workflow-docs/release.md
@@ -69,7 +69,7 @@ None (uses auto-provided `GITHUB_TOKEN`).
 - Uses `actions/checkout@v2`; should be upgraded to `v4`.
 - No actions are pinned to commit SHAs — all use mutable tag refs, which is a supply-chain risk.
 - `dependabot[bot]` actors are excluded.
-- `git describe` calls use `2>/dev/null || echo "v0.0.0"` fallback so the workflow does not fail on repos that have no tags yet.
+- `git describe` calls use `2>/dev/null || echo ""` (empty string) fallback. When no tag exists, `GIT_LOG_RANGE` resolves to `HEAD` (all commits) rather than the invalid ref `v0.0.0..HEAD`, which would cause `git log` to exit non-zero on a first release. The `Bump Version` step still uses a `v0.0.0` arithmetic base so the first release correctly becomes `v0.0.1`/`v0.1.0`/`v1.0.0`.
 - `MILESTONE_NUMBER` is validated non-empty before the GitHub API call; a missing or empty value exits 1 with a clear error rather than silently passing a malformed URL to `curl`.
 
 ---

--- a/workflow-docs/release.md
+++ b/workflow-docs/release.md
@@ -32,21 +32,15 @@ Automates the GitHub release creation process. Triggered by a `repository_dispat
 **Steps:**
 
 1. `actions/checkout@v2` — checks out `main` with full tag history
-2. `actions-ecosystem/action-get-merged-pull-request@v1` — retrieves the last merged PR
-3. `actions-ecosystem/action-release-label@v1` — determines release level from PR labels
-4. `actions-ecosystem/action-get-latest-tag@v1` — gets the latest semver tag
-5. `Determine Release Type` — parses commit messages; maps `BREAKING CHANGE`/`feat!` → major, `feat:` → minor, all others → patch
-6. `Bump Version` — increments the appropriate version component
-7. `Get Milestone Details` — fetches milestone title and description via GitHub API
-8. `Generate Changelog` — compiles changelog from merged PRs since last tag
-9. `Display Changelog` — prints to runner log
-10. `Attach Changelog to Release` — writes changelog content
-11. `Create Release` — creates the GitHub release with the new tag
-12. `Update CHANGELOG.md File` — prepends the new changelog entry
-13. `Update VERSION File` — writes new version string
-
----
-
+2. `Determine Release Type` — parses commit messages; maps `BREAKING CHANGE`/`feat!` → major, `feat:` → minor, all others → patch; uses `git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"` so repos with no tags default to `v0.0.0` rather than failing
+3. `Bump Version` — increments the appropriate version component; same `git describe` fallback applied here
+4. `Get Milestone Details` — validates `MILESTONE_NUMBER` from `client_payload` is non-empty (exits 1 with an error message if unset) then fetches milestone title and description via GitHub API
+5. `Generate Changelog` — compiles changelog from merged PRs since last tag
+6. `Display Changelog` — prints to runner log
+7. `Attach Changelog to Release` — writes changelog content
+8. `Create Release` — creates the GitHub release with the new tag
+9. `Update CHANGELOG.md File` — prepends the new changelog entry
+10. `Update VERSION File` — writes new version string
 ## Required Secrets
 
 None (uses auto-provided `GITHUB_TOKEN`).
@@ -66,9 +60,6 @@ None (uses auto-provided `GITHUB_TOKEN`).
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
 | `actions/checkout` | tag ref `v2` | — |
-| `actions-ecosystem/action-get-merged-pull-request` | tag ref `v1` | — |
-| `actions-ecosystem/action-release-label` | tag ref `v1` | — |
-| `actions-ecosystem/action-get-latest-tag` | tag ref `v1` | — |
 
 ---
 
@@ -78,6 +69,8 @@ None (uses auto-provided `GITHUB_TOKEN`).
 - Uses `actions/checkout@v2`; should be upgraded to `v4`.
 - No actions are pinned to commit SHAs — all use mutable tag refs, which is a supply-chain risk.
 - `dependabot[bot]` actors are excluded.
+- `git describe` calls use `2>/dev/null || echo "v0.0.0"` fallback so the workflow does not fail on repos that have no tags yet.
+- `MILESTONE_NUMBER` is validated non-empty before the GitHub API call; a missing or empty value exits 1 with a clear error rather than silently passing a malformed URL to `curl`.
 
 ---
 


### PR DESCRIPTION
﻿## Summary

Addresses all actionable CodeRabbit findings from sync PRs relay-service#130 and auth-service#165 (issue #56). Five separate commits - one per fix - for clean bisect history.

### Fix #1 - `npm ci` fails after `sed` rewrites `package.json` (package-rule.yml + package-rule-rc.yml)
`npm ci` requires the lockfile to exactly match `package.json`. The `sed` step that rewrites the rule dependency always invalidates the cloned `package-lock.json`. Change `npm ci` to `npm install`.

### Fix #2 - `git describe` hard-fails on repos with no tags (release.yml)
`git describe --abbrev=0 --tags` exits 128 on a tagless repo. Add `2>/dev/null || echo "v0.0.0"` fallback in both occurrences.

### Fix #3 - No guard for empty `MILESTONE_NUMBER` (release.yml)
If `repository_dispatch` fires without `milestone_number`, the curl URL becomes `.../milestones/` with no ID, returning a 200 array. `jq` then produces `null` metadata. Add an explicit empty-check that exits 1 with a clear `::error::` message.

### Fix #4 - Silent `RULE_ORG` fallthrough (package-rule.yml + package-rule-rc.yml)
Any value other than `frmscoe` silently fell through to the `tazama-lf` branch, including typos or blank values. Replace `if/else` + downstream ternary with a `case` statement that sets `EXPECTED_SCOPE` in each branch and exits 1 with `::error::` for unknown values.

### Fix #5 - Dual trigger in `dockerhub-image-build.yml`
**False positive** - not actioned. The `push: main` and `release: published` triggers serve different scenarios. `release.yml` does not push to main, so there is no duplicate build.

### Fix #6 - Three dead-code `actions-ecosystem` steps (release.yml)
`action-get-merged-pull-request`, `action-release-label`, and `action-get-latest-tag` form a chain where outputs only gate each other. No output is consumed downstream. Remove all three steps.

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build/release workflows: deterministic release behavior from commit messages, graceful handling when no prior tags, and stricter validation of required inputs (fails fast when missing).
  * Switched dependency installation to npm install to accommodate on-the-fly package edits.
* **Documentation**
  * Updated workflow docs to reflect the above changes and revised secret usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->