### PR TITLE
fix: upgrade actions/* pins to node24 runtime

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run Codacy Analysis CLI
         uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Initialize CodeQL
       uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
       with:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest  # Use the latest Ubuntu runner for the job
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: PR Conventional Commit Validation
         uses: ytanikin/PRConventionalCommits@b7be9213c4fa33260646db6c9b905332dc90b310  # 1.1.0

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
     # Step to check out the repository
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0  # Fetch all history for all branches to ensure complete commit history is available
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,6 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/dockerfile-linter.yml
+++ b/.github/workflows/dockerfile-linter.yml
@@ -35,7 +35,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run hadolint
         uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183

--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -31,7 +31,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121

--- a/.github/workflows/gpg-verify.yml
+++ b/.github/workflows/gpg-verify.yml
@@ -16,7 +16,7 @@ jobs:
       github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest  # Use the latest Ubuntu runner for the job
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0  # Fetch all history for all branches to ensure we have the full commit history
 

--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -35,7 +35,7 @@ jobs:
     name: njsscan code scanning
     steps:
     - name: Checkout the code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: nodejsscan scan
       id: njsscan
       continue-on-error: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,9 +28,9 @@ jobs:
       matrix:
         node-version: [20]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -50,9 +50,9 @@ jobs:
         node-version: [20]
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -72,9 +72,9 @@ jobs:
         node-version: [20]
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -55,10 +55,10 @@ jobs:
 
     steps:
       - name: Checkout rule repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: '20'
 

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -58,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout rule repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: '20'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GH_TOKEN_LIB }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com/'

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -60,13 +60,13 @@ jobs:
           echo "✅ Version input '$VERSION' is valid."
 
       - name: Checkout dev branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: dev
           token: ${{ secrets.GH_TOKEN_LIB }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com/'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checkout the main branch with all history
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4 (upgraded from v2)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 (upgraded from v2)
         with:
           ref: main
           fetch-depth: 0 # Fetch all tags
@@ -216,7 +216,7 @@ jobs:
       
       # Attach changelog as an artifact
       - name: Attach Changelog to Release
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: Changelog
           path: /home/runner/work/changelog.txt

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build the Docker image
       if: hashFiles('Dockerfile') != ''
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest  # Use the latest Ubuntu runner for the job
     steps:
       - name: Checkout Central Workflows Repo  # Step to checkout the repository containing the central workflows
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Reject prerelease version on main PR
         run: |


### PR DESCRIPTION
## Summary

GitHub has deprecated the Node.js 20 action runtime and will force migration to Node.js 24 by **June 2, 2026**, with Node.js 20 fully removed from runners on **September 16, 2026**.

This PR upgrades all affected action pins across every workflow file to their latest `node24`-runtime versions.

> **Note:** `node-version: 20` in `actions/setup-node` (the _application_ build runtime) is unrelated and intentionally unchanged.

## Changes

| Action | Old version | Old runtime | New version | New runtime |
|--------|------------|-------------|-------------|-------------|
| `actions/checkout` | `34e114876b` (v4) | node20 | `de0fac2e45` (v6.0.2) | **node24** |
| `actions/setup-node` | `49933ea528` (v4.4.0) | node20 | `53b83947a5` (v6.3.0) | **node24** |
| `actions/upload-artifact` | `ea165f8d65` (v4) | node20 | `bbbca2ddaa` (v7.0.0) | **node24** |

Files updated: `codacy.yml`, `codeql.yml`, `conventional-commits.yml`, `dco-check.yml`, `dependency-review.yml`, `dockerfile-linter.yml`, `dockerhub-image-build.yml`, `dockerhub-image-build-rc.yml`, `gpg-verify.yml`, `njsscan.yml`, `node.js.yml`, `package-rule.yml`, `package-rule-rc.yml`, `publish.yml`, `release-train.yml`, `release.yml`, `sbom.yml`, `sync-workflows.yml`, `version-check.yml`

`scorecard.yml` already used node24 pins and was left unchanged.

## Not upgraded

`actions/dependency-review-action@v4.9.0` is the **current latest release** and still runs on node20 — there is no node24 version available upstream yet. Will revisit when GitHub publishes one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies across CI/CD workflows to newer versions for improved compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->