### PR TITLE
fix: add newline before Signed-off-by in sync PR body

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -231,7 +231,9 @@ jobs:
               REVIEWERS_ARGS+="--reviewer $reviewer "
             done
 
-            gh pr create --title "ci: sync workflows from central-workflows" --body "This PR syncs workflows from the central-workflows repository. ${SIGNED_OFF_BY}" --base dev --head sync-workflows-update $REVIEWERS_ARGS || echo "PR already exists, updating existing PR"
+            gh pr create --title "ci: sync workflows from central-workflows" --body "This PR syncs workflows from the central-workflows repository.
+
+${SIGNED_OFF_BY}" --base dev --head sync-workflows-update $REVIEWERS_ARGS || echo "PR already exists, updating existing PR"
 
             cd ..
           done


### PR DESCRIPTION
The `Signed-off-by` trailer in the sync PR body was concatenated on the same line as the description text with only a space separator, causing it to render inline rather than as a proper trailer.

**Before:**
```
This PR syncs workflows from the central-workflows repository. Signed-off-by: ...
```

**After:**
```
This PR syncs workflows from the central-workflows repository.

Signed-off-by: ...
```

The fix adds a blank line before `${SIGNED_OFF_BY}` in the `gh pr create` `--body` argument.