### PR TITLE
fix: avoid blank line in YAML run block for PR body

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -231,9 +231,8 @@ jobs:
               REVIEWERS_ARGS+="--reviewer $reviewer "
             done
 
-            gh pr create --title "ci: sync workflows from central-workflows" --body "This PR syncs workflows from the central-workflows repository.
-
-${SIGNED_OFF_BY}" --base dev --head sync-workflows-update $REVIEWERS_ARGS || echo "PR already exists, updating existing PR"
+            PR_BODY="This PR syncs workflows from the central-workflows repository."$'\n\n'"${SIGNED_OFF_BY}"
+            gh pr create --title "ci: sync workflows from central-workflows" --body "$PR_BODY" --base dev --head sync-workflows-update $REVIEWERS_ARGS || echo "PR already exists, updating existing PR"
 
             cd ..
           done


### PR DESCRIPTION
Fixes the YAML syntax error introduced by PR #63.\n\nThe literal blank line inside the \--body\ string caused GitHub's YAML parser to terminate the \un:\ block scalar at line 236. The fix constructs the newline via bash \\$'\\n\\n'\ concatenation into a \PR_BODY\ variable, keeping the YAML valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub workflow structure for better maintainability without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->