### PR TITLE
feat: sign sync commits with SSH key for Verified status

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
@@ -73,6 +73,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -30,6 +30,16 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git config --global credential.helper store
+          # Configure SSH commit signing so sync commits show as Verified on GitHub.
+          # SSH_SIGNING_KEY must be stored as an org/repo secret (private key, no passphrase).
+          # The corresponding public key must be registered as a Signing Key on the GitHub account
+          # that GH_TOKEN belongs to: Settings → SSH and GPG keys → New signing key.
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/signing_key
+          git config --global commit.gpgsign true
 
       - name: Get actor details  # Step to get the triggering actor's details for the Signed-off-by line
         id: pr_author

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -34,9 +34,18 @@ jobs:
           # SSH_SIGNING_KEY must be stored as an org/repo secret (private key, no passphrase).
           # The corresponding public key must be registered as a Signing Key on the GitHub account
           # that GH_TOKEN belongs to: Settings → SSH and GPG keys → New signing key.
+          if [ -z "${{ secrets.SSH_SIGNING_KEY }}" ]; then
+            echo "::error::SSH_SIGNING_KEY secret is not set. Commits cannot be signed. Add the secret before running the sync." >&2
+            exit 1
+          fi
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_SIGNING_KEY }}" > ~/.ssh/signing_key
           chmod 600 ~/.ssh/signing_key
+          # Validate the key is a usable Ed25519/RSA private key before enabling signing.
+          ssh-keygen -y -f ~/.ssh/signing_key > /dev/null || {
+            echo "::error::SSH_SIGNING_KEY is not a valid SSH private key or is passphrase-protected. Fix the secret before running the sync." >&2
+            exit 1
+          }
           git config --global gpg.format ssh
           git config --global user.signingkey ~/.ssh/signing_key
           git config --global commit.gpgsign true


### PR DESCRIPTION
## Summary

Adds SSH commit signing to `sync-workflows.yml` so commits created by the sync job show as **Verified** on GitHub.

Also upgrades `codeql-action` v3 → v4.35.1 in `codeql.yml` (fixes #66).

## How it works

Before the repo loop, the workflow now:
1. Writes the private key from secret `SSH_SIGNING_KEY` to `~/.ssh/signing_key`
2. Configures git to use SSH signing (`gpg.format ssh`, `commit.gpgsign true`)

Every subsequent `git commit` in the loop is automatically signed.

## One-time setup required before merging

1. **Add secret** `SSH_SIGNING_KEY` to `tazama-lf/workflows` (org-level recommended) containing the Ed25519 private key.
2. **Register the public key** as a **Signing Key** (not SSH authentication key) on the GitHub account that `GH_TOKEN` belongs to:
   `Settings → SSH and GPG keys → New signing key`

The key pair has been generated separately and must **not** be committed to the repo.

### Closes

- Fixes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub CodeQL workflow to use a newer version for improved security analysis capabilities.
  * Configured Git commit signing for workflow-generated commits to ensure code authenticity and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->