### PR TITLE
feat: add dual-container repos and workflows to sync

### DIFF
--- a/.github/workflows/branch-target-check.yml
+++ b/.github/workflows/branch-target-check.yml
@@ -9,8 +9,8 @@
 # "prerelease version detected" message from version-check.yml.
 #
 # Allowed sources for PRs to main:
-#   dev          — the normal integration branch
-#   release/v<N>.* — release-train branches created by release-train.yml (must start with a digit)
+#   dev          - the normal integration branch
+#   release/v<N>.* - release-train branches created by release-train.yml (must start with a digit)
 #
 # Please do not attempt to edit this flow without the direct consent from the DevOps team.
 # This file is managed centrally.

--- a/.github/workflows/dockerhub-image-build-dual-rc.yml
+++ b/.github/workflows/dockerhub-image-build-dual-rc.yml
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+# This workflow is for repositories that produce two Docker images: a backend and a frontend.
+# Each image is built from its own subdirectory (./backend and ./frontend).
+# RC images are tagged with the floating alias "rc" rather than the package version.
+
+name: Publish Docker images RC (dual)
+
+on:
+  push:
+    branches: [ "dev" ]
+  workflow_dispatch:
+
+jobs:
+  push_backend_rc:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Push backend RC Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set ENV variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: tazamaorg/${{ env.REPO_NAME }}-backend
+          tags: |
+            type=raw,value=rc
+
+      - name: Build and push backend RC Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-backend
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
+
+      - name: Send Slack Notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+
+  push_frontend_rc:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Push frontend RC Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set ENV variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: tazamaorg/${{ env.REPO_NAME }}-frontend
+          tags: |
+            type=raw,value=rc
+
+      - name: Build and push frontend RC Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-frontend
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
+
+      - name: Send Slack Notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/dockerhub-image-build-dual.yml
+++ b/.github/workflows/dockerhub-image-build-dual.yml
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+# This workflow is for repositories that produce two Docker images: a backend and a frontend.
+# Each image is built from its own subdirectory (./backend and ./frontend) and versioned
+# independently from its own package.json.
+
+name: Publish Docker images (dual)
+
+on:
+  push:
+    branches: [ "main" ]
+  release:
+    types: [published]
+
+jobs:
+  push_backend:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Push backend Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set ENV variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Get backend package version
+        id: pkg_version
+        run: echo "VERSION=$(node -p "require('./backend/package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: tazamaorg/${{ env.REPO_NAME }}-backend
+          tags: |
+            type=raw,value=${{ steps.pkg_version.outputs.VERSION }}
+
+      - name: Build and push backend Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-backend
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Send Slack Notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+
+  push_frontend:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Push frontend Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set ENV variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Get frontend package version
+        id: pkg_version
+        run: echo "VERSION=$(node -p "require('./frontend/package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: tazamaorg/${{ env.REPO_NAME }}-frontend
+          tags: |
+            type=raw,value=${{ steps.pkg_version.outputs.VERSION }}
+
+      - name: Build and push frontend Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-frontend
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Send Slack Notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -119,15 +119,15 @@ jobs:
               ;;
           esac
 
-          # Validate rule dependency rewrite succeeded — fail if pattern didn't match
+          # Validate rule dependency rewrite succeeded - fail if pattern didn't match
           if ! grep -q "npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}" "${RULE_DIR}/package.json"; then
-            echo "❌ Failed to update rule dependency in package.json — pattern may have changed"
+            echo "❌ Failed to update rule dependency in package.json - pattern may have changed"
             echo "   Expected: npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}"
             grep '"rule"' "${RULE_DIR}/package.json" || echo "   (no 'rule' key found)"
             exit 1
           fi
 
-          # Update RULE_NAME and APM_SERVICE_NAME in Dockerfile (flexible pattern — not hardcoded to 901)
+          # Update RULE_NAME and APM_SERVICE_NAME in Dockerfile (flexible pattern - not hardcoded to 901)
           sed -i "s/ENV RULE_NAME=\"[^\"]*\"/ENV RULE_NAME=\"${RULE_NUM}\"/" "${RULE_DIR}/Dockerfile"
           sed -i "s/ENV APM_SERVICE_NAME=rule-[^ ]*/ENV APM_SERVICE_NAME=rule-${RULE_NUM}/" "${RULE_DIR}/Dockerfile"
 
@@ -136,13 +136,13 @@ jobs:
           echo "=== Dockerfile RULE_NAME after substitution ==="
           grep 'RULE_NAME\|APM_SERVICE_NAME' "${RULE_DIR}/Dockerfile"
 
-          # Validate substitutions actually occurred — fail fast if template changed upstream
+          # Validate substitutions actually occurred - fail fast if template changed upstream
           if ! grep -q "ENV RULE_NAME=\"${RULE_NUM}\"" "${RULE_DIR}/Dockerfile"; then
-            echo "❌ Failed to update RULE_NAME in Dockerfile — template may have changed"
+            echo "❌ Failed to update RULE_NAME in Dockerfile - template may have changed"
             exit 1
           fi
           if ! grep -q "ENV APM_SERVICE_NAME=rule-${RULE_NUM}" "${RULE_DIR}/Dockerfile"; then
-            echo "❌ Failed to update APM_SERVICE_NAME in Dockerfile — template may have changed"
+            echo "❌ Failed to update APM_SERVICE_NAME in Dockerfile - template may have changed"
             exit 1
           fi
 

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -75,7 +75,7 @@ jobs:
           fi
           if [[ "$VERSION" == *-* ]]; then
             echo "❌ Stable package-rule.yml triggered but version '$VERSION' is a prerelease."
-            echo "   Merge to main should be blocked by version-check.yml — investigate branch protection."
+            echo "   Merge to main should be blocked by version-check.yml - investigate branch protection."
             exit 1
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
@@ -119,15 +119,15 @@ jobs:
               ;;
           esac
 
-          # Validate rule dependency rewrite succeeded — fail if pattern didn't match
+          # Validate rule dependency rewrite succeeded - fail if pattern didn't match
           if ! grep -q "npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}" "${RULE_DIR}/package.json"; then
-            echo "❌ Failed to update rule dependency in package.json — pattern may have changed"
+            echo "❌ Failed to update rule dependency in package.json - pattern may have changed"
             echo "   Expected: npm:${EXPECTED_SCOPE}/rule-${RULE_NUM}@${VERSION}"
             grep '"rule"' "${RULE_DIR}/package.json" || echo "   (no 'rule' key found)"
             exit 1
           fi
 
-          # Update RULE_NAME and APM_SERVICE_NAME in Dockerfile (flexible pattern — not hardcoded to 901)
+          # Update RULE_NAME and APM_SERVICE_NAME in Dockerfile (flexible pattern - not hardcoded to 901)
           sed -i "s/ENV RULE_NAME=\"[^\"]*\"/ENV RULE_NAME=\"${RULE_NUM}\"/" "${RULE_DIR}/Dockerfile"
           sed -i "s/ENV APM_SERVICE_NAME=rule-[^ ]*/ENV APM_SERVICE_NAME=rule-${RULE_NUM}/" "${RULE_DIR}/Dockerfile"
 
@@ -136,13 +136,13 @@ jobs:
           echo "=== Dockerfile RULE_NAME after substitution ==="
           grep 'RULE_NAME\|APM_SERVICE_NAME' "${RULE_DIR}/Dockerfile"
 
-          # Validate substitutions actually occurred — fail fast if template changed upstream
+          # Validate substitutions actually occurred - fail fast if template changed upstream
           if ! grep -q "ENV RULE_NAME=\"${RULE_NUM}\"" "${RULE_DIR}/Dockerfile"; then
-            echo "❌ Failed to update RULE_NAME in Dockerfile — template may have changed"
+            echo "❌ Failed to update RULE_NAME in Dockerfile - template may have changed"
             exit 1
           fi
           if ! grep -q "ENV APM_SERVICE_NAME=rule-${RULE_NUM}" "${RULE_DIR}/Dockerfile"; then
-            echo "❌ Failed to update APM_SERVICE_NAME in Dockerfile — template may have changed"
+            echo "❌ Failed to update APM_SERVICE_NAME in Dockerfile - template may have changed"
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 
-      # Send Slack notification — requires SLACK_WEBHOOK_URL org/repo secret
+      # Send Slack notification - requires SLACK_WEBHOOK_URL org/repo secret
       - name: Send Slack notification
         continue-on-error: true
         env:

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -25,12 +25,12 @@ permissions:
   pull-requests: write
 
 # checkov:skip=CKV_GHA_7:Release train is operator-controlled; version input is validated and
-# only determines the release branch name / package.json version — not the build artifact source.
+# only determines the release branch name / package.json version - not the build artifact source.
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Target stable version (e.g. 4.0.0) — must not contain a prerelease suffix'
+        description: 'Target stable version (e.g. 4.0.0) - must not contain a prerelease suffix'
         required: true
         type: string
 
@@ -163,7 +163,7 @@ jobs:
           DEV_SHA=$(curl -s -H "Authorization: Bearer $GH_API_TOKEN" \
             "${API}/git/ref/heads/dev" | jq -r '.object.sha')
           if [ -z "$DEV_SHA" ] || [ "$DEV_SHA" = "null" ]; then
-            echo "❌ Failed to get dev branch SHA — check API permissions"
+            echo "❌ Failed to get dev branch SHA - check API permissions"
             exit 1
           fi
           echo "Dev SHA: $DEV_SHA"
@@ -177,7 +177,7 @@ jobs:
           if [ "$CREATE_HTTP" = "201" ]; then
             echo "Branch $BRANCH created at $DEV_SHA"
           else
-            echo "Branch $BRANCH already exists — force-resetting to dev HEAD ($DEV_SHA)"
+            echo "Branch $BRANCH already exists - force-resetting to dev HEAD ($DEV_SHA)"
             curl -s -X PATCH -H "Authorization: Bearer $GH_API_TOKEN" \
               -H "Content-Type: application/json" \
               "${API}/git/refs/heads/${BRANCH}" \
@@ -254,7 +254,7 @@ jobs:
             --reviewer "$GH_USERNAME"; then
             EXISTING=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number // empty')
             if [ -n "$EXISTING" ]; then
-              echo "PR #${EXISTING} already exists for $BRANCH — skipping."
+              echo "PR #${EXISTING} already exists for $BRANCH - skipping."
             else
               echo "❌ gh pr create failed and no existing PR was found."
               exit 1

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -40,7 +40,7 @@ jobs:
             exit 1
           fi
           mkdir -p ~/.ssh
-          # Decode the base64 secret directly to the key file — no line-ending issues possible.
+          # Decode the base64 secret directly to the key file - no line-ending issues possible.
           echo "${{ secrets.SSH_SIGNING_KEY }}" | base64 -d > ~/.ssh/signing_key
           chmod 600 ~/.ssh/signing_key
           # Validate the key is a usable Ed25519/RSA private key before enabling signing.
@@ -106,7 +106,7 @@ jobs:
             connection-studio
             rule-studio
           SPECIFIC_FILES: dockerhub-image-build.yml dockerhub-image-build-rc.yml  # Docker workflows: only for repos that build Docker images (i.e. not in SPECIFIC_REPOS)
-          SPECIFIC_REPOS: |  # Repos that do NOT build Docker images — receive all workflows except SPECIFIC_FILES
+          SPECIFIC_REPOS: |  # Repos that do NOT build Docker images - receive all workflows except SPECIFIC_FILES
             relay-service
             batch-ppa
             Full-Stack-Docker-Tazama
@@ -126,7 +126,7 @@ jobs:
             case-management-system
             connection-studio
             rule-studio
-          PUBLISH_REPOS: |  # Library repos that publish npm packages — the only repos that receive publish.yml and version-check.yml
+          PUBLISH_REPOS: |  # Library repos that publish npm packages - the only repos that receive publish.yml and version-check.yml
             frms-coe-lib
             frms-coe-startup-lib
             auth-lib
@@ -167,7 +167,7 @@ jobs:
             cd $repo
             git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/$ORG/$repo.git
 
-            # Ensure dev branch exists in target repo — create from default branch if absent.
+            # Ensure dev branch exists in target repo - create from default branch if absent.
             if ! git ls-remote --heads origin dev | grep -q dev; then
               DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
               echo "Branch 'dev' not found in $repo; creating from '${DEFAULT_BRANCH}'"
@@ -178,7 +178,7 @@ jobs:
             fi
 
             # Always delete and recreate sync-workflows-update to avoid accumulating stale changes.
-            # RESERVED: sync-workflows-update is managed by this workflow — do not use it for regular development contributions.
+            # RESERVED: sync-workflows-update is managed by this workflow - do not use it for regular development contributions.
             if git ls-remote --heads origin sync-workflows-update | grep -q sync-workflows-update; then
               git push origin --delete sync-workflows-update || true
             fi
@@ -198,11 +198,11 @@ jobs:
               if [[ "${filename}" == "publish.yml" || "${filename}" == "version-check.yml" || "${filename}" == "release-train.yml" ]] && ! in_list "$repo" "$PUBLISH_REPOS"; then
                 continue
               fi
-              # package-rule*.yml canonical definitions: never copy to rule repos — stubs are stamped below
+              # package-rule*.yml canonical definitions: never copy to rule repos - stubs are stamped below
               if in_list "$repo" "$RULE_REPOS" && [[ "${filename}" == package-rule*.yml ]]; then
                 continue
               fi
-              # scorecard.yml: only copy to service repos — skip library/npm repos and rule repos
+              # scorecard.yml: only copy to service repos - skip library/npm repos and rule repos
               if [[ "${filename}" == "scorecard.yml" ]] && in_list "$repo" "$PUBLISH_REPOS"; then
                 continue
               fi
@@ -215,7 +215,7 @@ jobs:
               # RC caller stub
               printf '%s\n' \
                 '# SPDX-License-Identifier: Apache-2.0' \
-                '# This file is managed centrally — do not edit manually.' \
+                '# This file is managed centrally - do not edit manually.' \
                 '# To change build behaviour, update the reusable workflow in tazama-lf/workflows.' \
                 'on:' \
                 '  push:' \
@@ -234,7 +234,7 @@ jobs:
               # Stable caller stub
               printf '%s\n' \
                 '# SPDX-License-Identifier: Apache-2.0' \
-                '# This file is managed centrally — do not edit manually.' \
+                '# This file is managed centrally - do not edit manually.' \
                 '# To change build behaviour, update the reusable workflow in tazama-lf/workflows.' \
                 'on:' \
                 '  push:' \

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -105,7 +105,7 @@ jobs:
             case-management-system
             connection-studio
             rule-studio
-          SPECIFIC_FILES: dockerhub-image-build.yml dockerhub-image-build-rc.yml dockerhub-image-build-dual.yml dockerhub-image-build-dual-rc.yml  # Docker workflows: only for repos that build Docker images (i.e. not in SPECIFIC_REPOS)
+          SPECIFIC_FILES: dockerhub-image-build.yml dockerhub-image-build-rc.yml  # Docker workflows: only for repos that build Docker images (i.e. not in SPECIFIC_REPOS)
           SPECIFIC_REPOS: |  # Repos that do NOT build Docker images — receive all workflows except SPECIFIC_FILES
             relay-service
             batch-ppa
@@ -152,6 +152,8 @@ jobs:
           cp -r .github/workflows/* temp-workflows/
           rm temp-workflows/sync-workflows.yml  # Remove the sync-workflows.yml to avoid recursive syncing
           rm -f temp-workflows/node.js.yml  # Remove per-repo CI workflow to avoid overwriting repo-specific benchmarks
+          rm -f temp-workflows/dockerhub-image-build-dual.yml     # Dual-container Docker workflows: never synced; committed directly to target repos
+          rm -f temp-workflows/dockerhub-image-build-dual-rc.yml  # Dual-container Docker workflows: never synced; committed directly to target repos
 
           # Helper: check membership in a newline-delimited list (YAML block scalar)
           # Space-delimited single-line vars (SPECIFIC_FILES) use the [[ =~ ]] pattern directly.

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -100,7 +100,12 @@ jobs:
             relay-service-integration-kafka
             relay-service-integration-rabbitmq
             audit-lib
-          SPECIFIC_FILES: dockerhub-image-build.yml dockerhub-image-build-rc.yml  # Docker workflows: only for repos that build Docker images (i.e. not in SPECIFIC_REPOS)
+            data-enrichment-service
+            event-monitoring-service
+            case-management-system
+            connection-studio
+            rule-studio
+          SPECIFIC_FILES: dockerhub-image-build.yml dockerhub-image-build-rc.yml dockerhub-image-build-dual.yml dockerhub-image-build-dual-rc.yml  # Docker workflows: only for repos that build Docker images (i.e. not in SPECIFIC_REPOS)
           SPECIFIC_REPOS: |  # Repos that do NOT build Docker images — receive all workflows except SPECIFIC_FILES
             relay-service
             batch-ppa
@@ -118,6 +123,9 @@ jobs:
             relay-service-integration-kafka
             relay-service-integration-rabbitmq
             audit-lib
+            case-management-system
+            connection-studio
+            rule-studio
           PUBLISH_REPOS: |  # Library repos that publish npm packages — the only repos that receive publish.yml and version-check.yml
             frms-coe-lib
             frms-coe-startup-lib

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -4,7 +4,7 @@
 # version suffix (e.g. -rc.1). The developer must strip the suffix manually
 # in the release PR before this check will pass.
 #
-# This is the companion guard for the push: main trigger in publish.yml —
+# This is the companion guard for the push: main trigger in publish.yml -
 # it ensures that only clean semver versions (X.Y.Z) ever reach main and
 # are published as the 'latest' dist-tag.
 #
@@ -44,4 +44,4 @@ jobs:
             echo "   Strip the suffix (e.g. change '$VERSION' → '${VERSION%-*}') before merging to main."
             exit 1
           fi
-          echo "✅ Version '$VERSION' is a clean release version — OK to merge."
+          echo "✅ Version '$VERSION' is a clean release version - OK to merge."

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Each repository in the Tazama ecosystem belongs to one class. The class determin
 |-------|-------|--------|-------|
 | **Service repos** | `auth-service`, `typology-processor`, `event-director`, `event-flow`, `event-sidecar`, `lumberjack`, `nats-utilities`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `data-enrichment-service`, `event-monitoring-service` | Docker image | Publish to Docker Hub; receive full workflow set including Docker build workflows |
 | **Dual-container service repos** | `case-management-system`, `connection-studio`, `rule-studio` | Docker images (backend + frontend) | Each repo produces two Docker images from `backend/` and `frontend/` subdirectories; in `SPECIFIC_REPOS` so do not receive the single-image `dockerhub-image-build*.yml`; use `dockerhub-image-build-dual*.yml` committed directly instead |
-| **Other service repos** | `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` | — | In `SPECIFIC_REPOS`; do not receive `dockerhub-image-build*.yml` |
+| **Other service repos** | `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` | - | In `SPECIFIC_REPOS`; do not receive `dockerhub-image-build*.yml` |
 | **Library repos** | `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `tcs-lib`, `audit-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq` | npm package | Publish to GitHub Packages under `@tazama-lf` scope |
-| **Rule repos — tazama-lf** | `rule-901`, `rule-902` | Docker image + npm package | Also in `PUBLISH_REPOS`; use `package-rule*.yml` caller stubs for Docker builds |
-| **Rule repos — frmscoe** | `rule-001` through `rule-091` (33 active repos) | Docker image | Managed via [`frmscoe/workflows`](https://github.com/frmscoe/workflows); receive Docker builds via `package-rule*.yml` caller stubs |
-| **Workflow repos** | `tazama-lf/workflows` (this repo), `frmscoe/workflows` | — | Canonical; not synced to |
+| **Rule repos - tazama-lf** | `rule-901`, `rule-902` | Docker image + npm package | Also in `PUBLISH_REPOS`; use `package-rule*.yml` caller stubs for Docker builds |
+| **Rule repos - frmscoe** | `rule-001` through `rule-091` (33 active repos) | Docker image | Managed via [`frmscoe/workflows`](https://github.com/frmscoe/workflows); receive Docker builds via `package-rule*.yml` caller stubs |
+| **Workflow repos** | `tazama-lf/workflows` (this repo), `frmscoe/workflows` | - | Canonical; not synced to |
 
 ---
 
@@ -32,15 +32,15 @@ The following checks run automatically on pull requests across all repo classes.
 
 | Workflow | What it checks |
 |----------|---------------|
-| `branch-target-check.yml` | PR base branch must be `dev` or `release/v*` when targeting `main` — **fires on PRs to `main` only** |
+| `branch-target-check.yml` | PR base branch must be `dev` or `release/v*` when targeting `main` - **fires on PRs to `main` only** |
 | `conventional-commits.yml` | PR title is validated against the [Conventional Commits](https://www.conventionalcommits.org/) specification |
-| `dco-check.yml` | All commits carry a DCO `Signed-off-by` trailer — ⚠️ [known issue #37](https://github.com/tazama-lf/workflows/issues/37) |
+| `dco-check.yml` | All commits carry a DCO `Signed-off-by` trailer - ⚠️ [known issue #37](https://github.com/tazama-lf/workflows/issues/37) |
 | `gpg-verify.yml` | All commits are GPG-signed |
-| `codacy.yml` | Static analysis via Codacy CLI — ⚠️ [known issue #38](https://github.com/tazama-lf/workflows/issues/38) |
+| `codacy.yml` | Static analysis via Codacy CLI - ⚠️ [known issue #38](https://github.com/tazama-lf/workflows/issues/38) |
 | `codeql.yml` | GitHub CodeQL SAST security scan |
 | `njsscan.yml` | Node.js-specific security scan (semgrep rules) |
 | `dependency-review.yml` | Flags new dependencies with known CVEs or licence restrictions |
-| `node.js.yml` | Build, lint, and test on Node 20 — **not synced; each repo maintains its own copy** |
+| `node.js.yml` | Build, lint, and test on Node 20 - **not synced; each repo maintains its own copy** |
 
 > Pre-commit tooling (local linting, formatting, commit-msg hooks) is developer-local and not managed here. See the project [contribution guide](https://github.com/tazama-lf/tazama-documentation) for local setup guidance.
 
@@ -54,22 +54,22 @@ Library repos publish versioned npm packages under the `@tazama-lf` scope. They 
 
 #### Feature development → dev
 
-1. **Developer** — develops changes on a feature branch.
-2. **Developer — MANUAL** — bumps `version` in `package.json` to `X.Y.Z-rc.N`.
-3. **Developer** — opens pull request targeting `dev`.
-4. **AUTO** — [standard PR check suite](#standard-pr-check-suite) fires.
-5. **Reviewer — MANUAL** — reviews, approves, merges PR to `dev`.
-6. **AUTO** — `publish.yml` fires on `push: dev`; detects the `-rc` suffix; publishes the package to GitHub Packages under the `rc` dist-tag.
+1. **Developer** - develops changes on a feature branch.
+2. **Developer - MANUAL** - bumps `version` in `package.json` to `X.Y.Z-rc.N`.
+3. **Developer** - opens pull request targeting `dev`.
+4. **AUTO** - [standard PR check suite](#standard-pr-check-suite) fires.
+5. **Reviewer - MANUAL** - reviews, approves, merges PR to `dev`.
+6. **AUTO** - `publish.yml` fires on `push: dev`; detects the `-rc` suffix; publishes the package to GitHub Packages under the `rc` dist-tag.
 
 #### Release → main
 
-1. **Developer — MANUAL** — triggers `release-train.yml` via `workflow_dispatch` from `dev`; enters the target stable version (e.g. `4.0.0`, no prerelease suffix).
-2. **AUTO** — `release-train.yml` resolves all `-rc.*` dependencies to their stable equivalents, regenerates `package-lock.json`, and opens a `release/vX.Y.Z → main` PR. Fails if any dependency has no stable release yet.
-3. **Developer — MANUAL** — in the release PR branch, strips the `-rc.N` suffix from `version` in `package.json`.
-4. **AUTO** — `version-check.yml` fires on the PR targeting `main`; blocks merge if the version still contains a prerelease suffix.
-5. **AUTO** — full standard PR check suite also fires on the `main`-targeting PR.
-6. **Reviewer — MANUAL** — reviews and merges the release PR to `main`.
-7. **AUTO** — `publish.yml` fires on `push: main`; detects a clean semver; publishes the package under the `latest` dist-tag.
+1. **Developer - MANUAL** - triggers `release-train.yml` via `workflow_dispatch` from `dev`; enters the target stable version (e.g. `4.0.0`, no prerelease suffix).
+2. **AUTO** - `release-train.yml` resolves all `-rc.*` dependencies to their stable equivalents, regenerates `package-lock.json`, and opens a `release/vX.Y.Z → main` PR. Fails if any dependency has no stable release yet.
+3. **Developer - MANUAL** - in the release PR branch, strips the `-rc.N` suffix from `version` in `package.json`.
+4. **AUTO** - `version-check.yml` fires on the PR targeting `main`; blocks merge if the version still contains a prerelease suffix.
+5. **AUTO** - full standard PR check suite also fires on the `main`-targeting PR.
+6. **Reviewer - MANUAL** - reviews and merges the release PR to `main`.
+7. **AUTO** - `publish.yml` fires on `push: main`; detects a clean semver; publishes the package under the `latest` dist-tag.
 
 ---
 
@@ -79,24 +79,24 @@ Service repos produce versioned Docker images. They do not publish npm packages.
 
 #### Feature development → dev
 
-1. **Developer — MANUAL** — updates library dependency versions in `package.json` to consume any new rc or stable library releases (this step follows the [library release cycle](#1-library-repos-publish_repos) upstream).
-2. **Developer** — develops changes on a feature branch.
-3. **Developer** — opens pull request targeting `dev`.
-4. **AUTO** — [standard PR check suite](#standard-pr-check-suite) fires, plus `dockerfile-linter.yml` if a `Dockerfile` was modified.
-5. **Reviewer — MANUAL** — reviews, approves, merges PR to `dev`.
-6. **AUTO** — `dockerhub-image-build-rc.yml` fires on `push: dev`; builds and pushes the Docker image tagged `:rc` to Docker Hub.
-7. **AUTO** — `scorecard.yml` fires on `push: dev`; runs OSSF supply-chain checks (results published to the Security tab only on `main`, schedule, and `branch_protection_rule` triggers).
+1. **Developer - MANUAL** - updates library dependency versions in `package.json` to consume any new rc or stable library releases (this step follows the [library release cycle](#1-library-repos-publish_repos) upstream).
+2. **Developer** - develops changes on a feature branch.
+3. **Developer** - opens pull request targeting `dev`.
+4. **AUTO** - [standard PR check suite](#standard-pr-check-suite) fires, plus `dockerfile-linter.yml` if a `Dockerfile` was modified.
+5. **Reviewer - MANUAL** - reviews, approves, merges PR to `dev`.
+6. **AUTO** - `dockerhub-image-build-rc.yml` fires on `push: dev`; builds and pushes the Docker image tagged `:rc` to Docker Hub.
+7. **AUTO** - `scorecard.yml` fires on `push: dev`; runs OSSF supply-chain checks (results published to the Security tab only on `main`, schedule, and `branch_protection_rule` triggers).
 
 #### Release → main
 
-1. **Developer** — opens pull request `dev → main`.
-2. **AUTO** — standard PR check suite fires.
-3. **Reviewer — MANUAL** — reviews, approves, merges to `main`.
-4. **AUTO** — `dockerhub-image-build.yml` fires on `push: main`; reads `version` from `package.json`; builds and pushes the Docker image tagged `:X.Y.Z` to Docker Hub.
-5. **AUTO** — `sbom.yml` fires on `push: main`; generates a Software Bill of Materials from the Docker image — ⚠️ [known issue #39](https://github.com/tazama-lf/workflows/issues/39).
-6. **Release manager — MANUAL** — triggers `milestone.yml` via `workflow_dispatch` in the service repo, supplying the milestone ID.
-7. **AUTO** — `milestone.yml` closes the milestone and fires `release.yml` via `repository_dispatch`.
-8. **AUTO** — `release.yml` determines the version bump from commit messages, generates a changelog from merged PRs, and creates the GitHub release with the changelog as the release body (no `CHANGELOG.md` or `VERSION` files are written to the repository) — ⚠️ [known issue #40](https://github.com/tazama-lf/workflows/issues/40).
+1. **Developer** - opens pull request `dev → main`.
+2. **AUTO** - standard PR check suite fires.
+3. **Reviewer - MANUAL** - reviews, approves, merges to `main`.
+4. **AUTO** - `dockerhub-image-build.yml` fires on `push: main`; reads `version` from `package.json`; builds and pushes the Docker image tagged `:X.Y.Z` to Docker Hub.
+5. **AUTO** - `sbom.yml` fires on `push: main`; generates a Software Bill of Materials from the Docker image - ⚠️ [known issue #39](https://github.com/tazama-lf/workflows/issues/39).
+6. **Release manager - MANUAL** - triggers `milestone.yml` via `workflow_dispatch` in the service repo, supplying the milestone ID.
+7. **AUTO** - `milestone.yml` closes the milestone and fires `release.yml` via `repository_dispatch`.
+8. **AUTO** - `release.yml` determines the version bump from commit messages, generates a changelog from merged PRs, and creates the GitHub release with the changelog as the release body (no `CHANGELOG.md` or `VERSION` files are written to the repository) - ⚠️ [known issue #40](https://github.com/tazama-lf/workflows/issues/40).
 
 ---
 
@@ -106,8 +106,8 @@ These repos follow the same PR check and release flow as standard Docker-buildin
 
 They are listed in both `REPOS` (to receive all common workflows) and `SPECIFIC_REPOS` (to suppress the single-image `dockerhub-image-build*.yml`). The dual-image Docker workflows are **not distributed via sync** and must be committed directly to each repo:
 
-- `dockerhub-image-build-dual-rc.yml` — fires on `push: dev`; builds and pushes `tazamaorg/<repo>-backend:rc` and `tazamaorg/<repo>-frontend:rc`
-- `dockerhub-image-build-dual.yml` — fires on `push: main`; builds and pushes `tazamaorg/<repo>-backend:<version>` and `tazamaorg/<repo>-frontend:<version>`
+- `dockerhub-image-build-dual-rc.yml` - fires on `push: dev`; builds and pushes `tazamaorg/<repo>-backend:rc` and `tazamaorg/<repo>-frontend:rc`
+- `dockerhub-image-build-dual.yml` - fires on `push: main`; builds and pushes `tazamaorg/<repo>-backend:<version>` and `tazamaorg/<repo>-frontend:<version>`
 
 All other steps (PR checks, `sbom.yml`, `scorecard.yml`, `release.yml`, etc.) are identical to [Section 2](#2-service-repos-docker-building).
 
@@ -119,19 +119,19 @@ All other steps (PR checks, `sbom.yml`, `scorecard.yml`, `release.yml`, etc.) ar
 
 ---
 
-### 5. Rule repos — tazama-lf (rule-901, rule-902)
+### 5. Rule repos - tazama-lf (rule-901, rule-902)
 
 tazama-lf rule repos are both library repos **and** Docker image producers. They follow the full library release cycle for npm publishing (including `release-train.yml`, `publish.yml`, and `version-check.yml`) and additionally build Docker images via the `package-rule*.yml` reusable workflows.
 
-1. **Merged to `dev`** — same as library repos: `publish.yml` fires and publishes the rc npm package.
-2. **AUTO** — `package-rule-rc.yml` caller stub fires on `push: dev`; calls the reusable workflow at `tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev`; builds and pushes the Docker image tagged `:rc`.
-3. **Release to `main`** — same as library repos: `release-train.yml` resolves deps, opens release PR, `version-check.yml` guards the merge.
-4. **Merged to `main`** — `publish.yml` fires and publishes the stable npm package.
-5. **AUTO** — `package-rule.yml` caller stub fires on `push: main`; calls the reusable workflow; builds and pushes Docker images tagged `:X.Y.Z` and `:latest`.
+1. **Merged to `dev`** - same as library repos: `publish.yml` fires and publishes the rc npm package.
+2. **AUTO** - `package-rule-rc.yml` caller stub fires on `push: dev`; calls the reusable workflow at `tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev`; builds and pushes the Docker image tagged `:rc`.
+3. **Release to `main`** - same as library repos: `release-train.yml` resolves deps, opens release PR, `version-check.yml` guards the merge.
+4. **Merged to `main`** - `publish.yml` fires and publishes the stable npm package.
+5. **AUTO** - `package-rule.yml` caller stub fires on `push: main`; calls the reusable workflow; builds and pushes Docker images tagged `:X.Y.Z` and `:latest`.
 
 ---
 
-### 6. Rule repos — frmscoe (rule-001 through rule-091)
+### 6. Rule repos - frmscoe (rule-001 through rule-091)
 
 frmscoe rule repos reside in the `frmscoe` organisation and are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which is a manually-maintained mirror of the relevant subset of workflows from this repo. frmscoe rule repos build Docker images via `package-rule*.yml` caller stubs (referencing `frmscoe/workflows` as the reusable workflow source) but do not use `dockerhub-image-build*.yml` or `dockerfile-linter.yml`.
 
@@ -139,19 +139,19 @@ frmscoe rule repos reside in the `frmscoe` organisation and are managed by [`frm
 
 **Not received:** `dockerfile-linter.yml`, `dockerhub-image-build.yml`, `dockerhub-image-build-rc.yml`.
 
-**Sync trigger in frmscoe/workflows:** `push: dev` (not `pull_request` — sync fires after merge, not on PR open).
+**Sync trigger in frmscoe/workflows:** `push: dev` (not `pull_request` - sync fires after merge, not on PR open).
 
 #### SDLC
 
-1. **Developer** — develops changes on a feature branch.
-2. **Developer** — opens pull request targeting `dev`.
-3. **AUTO** — [standard PR check suite](#standard-pr-check-suite) fires.
-4. **Reviewer — MANUAL** — reviews, approves, merges to `dev`.
-5. **AUTO** — `package-rule-rc.yml` caller stub fires on `push: dev`; builds and pushes the rule Docker image tagged `:rc`.
-6. **Developer** — opens pull request `dev → main` for the release.
-7. **AUTO** — standard PR check suite fires.
-8. **Reviewer — MANUAL** — reviews, approves, merges to `main`.
-9. **AUTO** — `package-rule.yml` caller stub fires on `push: main`; builds and pushes Docker images tagged `:X.Y.Z` and `:latest`.
+1. **Developer** - develops changes on a feature branch.
+2. **Developer** - opens pull request targeting `dev`.
+3. **AUTO** - [standard PR check suite](#standard-pr-check-suite) fires.
+4. **Reviewer - MANUAL** - reviews, approves, merges to `dev`.
+5. **AUTO** - `package-rule-rc.yml` caller stub fires on `push: dev`; builds and pushes the rule Docker image tagged `:rc`.
+6. **Developer** - opens pull request `dev → main` for the release.
+7. **AUTO** - standard PR check suite fires.
+8. **Reviewer - MANUAL** - reviews, approves, merges to `main`.
+9. **AUTO** - `package-rule.yml` caller stub fires on `push: main`; builds and pushes Docker images tagged `:X.Y.Z` and `:latest`.
 
 ---
 
@@ -159,14 +159,14 @@ frmscoe rule repos reside in the `frmscoe` organisation and are managed by [`frm
 
 Changes to this repo propagate to all 31 target repositories. This is the highest-impact SDLC path.
 
-1. **DevOps** — modifies workflow files in `.github/workflows/`; updates the corresponding `workflow-docs/` entry.
-2. **DevOps** — opens pull request targeting `dev`.
-3. **AUTO** — standard PR check suite fires against this repo.
-4. **Reviewer — MANUAL** — reviews and merges the source PR to `dev` in this repo.
-5. **AUTO** — `sync-workflows.yml` fires on `push: dev`; opens `sync-workflows-update` PRs in all 31 target repos.
-6. **Reviewers in target repos — MANUAL** — merge `sync-workflows-update` PRs in each target repo.
-7. **DevOps — MANUAL** — applies the same changes to [`frmscoe/workflows`](https://github.com/frmscoe/workflows) via a separate PR (no automated mirror exists between the two workflow repos).
-8. **AUTO** — once merged to `dev` in `frmscoe/workflows`, its `sync-workflows.yml` fires on `push: dev` and distributes the changes to all 33 frmscoe rule repos.
+1. **DevOps** - modifies workflow files in `.github/workflows/`; updates the corresponding `workflow-docs/` entry.
+2. **DevOps** - opens pull request targeting `dev`.
+3. **AUTO** - standard PR check suite fires against this repo.
+4. **Reviewer - MANUAL** - reviews and merges the source PR to `dev` in this repo.
+5. **AUTO** - `sync-workflows.yml` fires on `push: dev`; opens `sync-workflows-update` PRs in all 31 target repos.
+6. **Reviewers in target repos - MANUAL** - merge `sync-workflows-update` PRs in each target repo.
+7. **DevOps - MANUAL** - applies the same changes to [`frmscoe/workflows`](https://github.com/frmscoe/workflows) via a separate PR (no automated mirror exists between the two workflow repos).
+8. **AUTO** - once merged to `dev` in `frmscoe/workflows`, its `sync-workflows.yml` fires on `push: dev` and distributes the changes to all 33 frmscoe rule repos.
 
 ---
 
@@ -183,22 +183,22 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `dco-check.yml` | Verify DCO Signed-off-by on commits | `pull_request` | All repos |
 | `dependency-review.yml` | Flag CVEs and licence issues in new deps | `pull_request` | All repos |
 | `dockerfile-linter.yml` | Hadolint lint of Dockerfiles | `pull_request` | All repos (no-op where no `Dockerfile` exists) |
-| `dockerhub-image-build-dual-rc.yml` | Build and push `:rc` Docker images for backend and frontend | `push: [dev]`, `workflow_dispatch` | **Not synced** — committed directly to dual-container repos only |
-| `dockerhub-image-build-dual.yml` | Build and push versioned Docker images for backend and frontend | `push: [main]`, `release: [published]` | **Not synced** — committed directly to dual-container repos only |
+| `dockerhub-image-build-dual-rc.yml` | Build and push `:rc` Docker images for backend and frontend | `push: [dev]`, `workflow_dispatch` | **Not synced** - committed directly to dual-container repos only |
+| `dockerhub-image-build-dual.yml` | Build and push versioned Docker images for backend and frontend | `push: [main]`, `release: [published]` | **Not synced** - committed directly to dual-container repos only |
 | `dockerhub-image-build-rc.yml` | Build and push `:rc` Docker image | `push: [dev]` | Service repos only (not SPECIFIC_REPOS) |
 | `dockerhub-image-build.yml` | Build and push versioned Docker image | `push: [main]` | Service repos only (not SPECIFIC_REPOS) |
 | `gpg-verify.yml` | Verify GPG signature on commits | `pull_request` | All repos |
 | `milestone.yml` | Close a milestone and trigger `release.yml` | `workflow_dispatch` | All repos |
 | `njsscan.yml` | Node.js security scan (semgrep) | `push`, `pull_request` | All repos |
-| `node.js.yml` | Node 20 CI: build, lint, test | `push: [dev,main]`, `pull_request: [dev,main]` | **Not synced** — each repo maintains its own copy |
+| `node.js.yml` | Node 20 CI: build, lint, test | `push: [dev,main]`, `pull_request: [dev,main]` | **Not synced** - each repo maintains its own copy |
 | `package-rule-rc.yml` | Reusable: build and push `:rc` Docker image for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `package-rule.yml` | Reusable: build and push `:latest`/`:X.Y.Z` Docker images for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `publish.yml` | Publish npm package to GitHub Packages | `push: [main]`, `workflow_dispatch` | `PUBLISH_REPOS` only |
 | `release-train.yml` | Resolve rc deps, prepare release PR, bump version | `workflow_dispatch` | `PUBLISH_REPOS` only |
 | `release.yml` | Create GitHub release with auto-generated changelog as release body | `repository_dispatch: [release]` (from `milestone.yml`) | All repos |
-| `sbom.yml` | Generate SBOM from Docker image | `push: [main]` | All repos — ⚠️ [known issue #39](https://github.com/tazama-lf/workflows/issues/39) |
+| `sbom.yml` | Generate SBOM from Docker image | `push: [main]` | All repos - ⚠️ [known issue #39](https://github.com/tazama-lf/workflows/issues/39) |
 | `scorecard.yml` | OSSF Scorecard supply-chain security | `push: [main,dev]`, schedule (weekly), `branch_protection_rule` | Service repos only (not `PUBLISH_REPOS`) |
-| `sync-workflows.yml` | Distribute canonical workflows to all target repos | `push: [dev]`, `workflow_dispatch` | **Not synced** — canonical-only |
+| `sync-workflows.yml` | Distribute canonical workflows to all target repos | `push: [dev]`, `workflow_dispatch` | **Not synced** - canonical-only |
 | `version-check.yml` | Block PR to `main` if `package.json` version has a prerelease suffix | `pull_request: [main]` | `PUBLISH_REPOS` only |
 
 ---
@@ -225,7 +225,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 
 > **frmscoe rule repos are not in this list.** They are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which syncs to 33 rule repos (`rule-001` through `rule-091`, active subset) via its own `sync-workflows.yml` triggered on `push: dev`.
 
-> ⚠️ **`sync-workflows-update` is a reserved branch name.** This branch is created and managed by `sync-workflows.yml` in every target repo. Do not use this name for regular development contributions — the sync workflow will delete it and recreate it fresh from `dev` on every run. If you have an open `sync-workflows-update` branch in a target repo, be aware it will be force-replaced the next time the workflow runs.
+> ⚠️ **`sync-workflows-update` is a reserved branch name.** This branch is created and managed by `sync-workflows.yml` in every target repo. Do not use this name for regular development contributions - the sync workflow will delete it and recreate it fresh from `dev` on every run. If you have an open `sync-workflows-update` branch in a target repo, be aware it will be force-replaced the next time the workflow runs.
 
 ---
 
@@ -233,17 +233,17 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 
 When a new repository is created in the Tazama ecosystem, it needs to be enrolled in sync so it receives canonical workflows automatically on future updates. The steps depend on the [repository class](#repository-classes).
 
-### Step 1 — Determine the repository class
+### Step 1 - Determine the repository class
 
 | Class | Receives Docker build workflows? | Receives `publish.yml` / `release-train.yml`? |
 |-------|----------------------------------|-----------------------------------------------|
 | Service repo (Docker-building) | ✅ Yes | ❌ No |
 | Other service repo (no Docker build) | ❌ No (add to `SPECIFIC_REPOS`) | ❌ No |
 | Library repo | ❌ No (add to `SPECIFIC_REPOS`) | ✅ Yes (add to `PUBLISH_REPOS`) |
-| Rule repo — tazama-lf | ❌ No (add to `SPECIFIC_REPOS` + `RULE_REPOS`) | ✅ Yes (add to `PUBLISH_REPOS`) |
-| Rule repo — frmscoe | n/a — managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows) | n/a |
+| Rule repo - tazama-lf | ❌ No (add to `SPECIFIC_REPOS` + `RULE_REPOS`) | ✅ Yes (add to `PUBLISH_REPOS`) |
+| Rule repo - frmscoe | n/a - managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows) | n/a |
 
-### Step 2 — Add the repo to `sync-workflows.yml` in this repo
+### Step 2 - Add the repo to `sync-workflows.yml` in this repo
 
 Open `.github/workflows/sync-workflows.yml` and add the repo name to the appropriate `env` lists:
 
@@ -252,9 +252,9 @@ Open `.github/workflows/sync-workflows.yml` and add the repo name to the appropr
 - **Library or tazama-lf rule repo**: also add to `PUBLISH_REPOS`
 - **tazama-lf rule repo**: also add to `RULE_REPOS`
 
-> Library repos (`PUBLISH_REPOS`) are cloned from `tazama-lf`; service repos are cloned from `frmscoe` (see [known issue #28](https://github.com/tazama-lf/workflows/issues/28) — full org migration pending).
+> Library repos (`PUBLISH_REPOS`) are cloned from `tazama-lf`; service repos are cloned from `frmscoe` (see [known issue #28](https://github.com/tazama-lf/workflows/issues/28) - full org migration pending).
 
-### Step 3 — Bootstrap the new repo's workflow directory
+### Step 3 - Bootstrap the new repo's workflow directory
 
 `sync-workflows.yml` only runs against repos that already have a `.github/workflows/` directory. For a brand-new repo, copy the relevant workflows manually from this repo's `.github/workflows/` before raising the sync PR:
 
@@ -264,13 +264,13 @@ Open `.github/workflows/sync-workflows.yml` and add the repo name to the appropr
 4. Commit directly to `dev` in the new repo (or raise a bootstrap PR).
 5. Copy `node.js.yml` manually and customise it for the repo (it is never synced).
 
-### Step 4 — Open a PR to `dev` in this repo
+### Step 4 - Open a PR to `dev` in this repo
 
-Raise a PR with the `sync-workflows.yml` changes from Step 2. When the PR is opened, `sync-workflows.yml` runs (due to the `pull_request: dev` trigger) and creates `sync-workflows-update` PRs in all existing repos — the new entry will be included.
+Raise a PR with the `sync-workflows.yml` changes from Step 2. When the PR is opened, `sync-workflows.yml` runs (due to the `pull_request: dev` trigger) and creates `sync-workflows-update` PRs in all existing repos - the new entry will be included.
 
-> ⚠️ Do not merge the sync PRs in target repos until this source PR is confirmed merged — see [known issue #36](https://github.com/tazama-lf/workflows/issues/36).
+> ⚠️ Do not merge the sync PRs in target repos until this source PR is confirmed merged - see [known issue #36](https://github.com/tazama-lf/workflows/issues/36).
 
-### Step 5 — Update `workflow-docs/`
+### Step 5 - Update `workflow-docs/`
 
 Add a documentation file for any new canonical workflow using [`workflow-docs/docs-template.md`](workflow-docs/docs-template.md) as a starting point, and update the [Canonical Workflow Reference](#canonical-workflow-reference) table and [Sync Distribution](#sync-distribution) section if the new repo changes group membership.
 
@@ -352,9 +352,9 @@ Active bugs where workflow behaviour differs from expectation. See the [issues t
 
 | Issue | Affected workflow(s) | Reference |
 |-------|---------------------|-----------|
-| `sync-workflows.yml` fires on all PR events to `dev`, not only on merge — do not merge sync PRs in target repos until the source PR here is confirmed merged | `sync-workflows.yml` | [#36](https://github.com/tazama-lf/workflows/issues/36) |
-| `dco-check.yml` uses a reversed `git log` range — DCO sign-off is not being verified on the actual PR commits | `dco-check.yml` | [#37](https://github.com/tazama-lf/workflows/issues/37) |
-| Codacy CLI crashes with `MalformedInputException` on checkov output from multi-line YAML files — workaround: add `.checkov.yaml` with `skip-framework: github_actions` at the repo root | `codacy.yml` | [#38](https://github.com/tazama-lf/workflows/issues/38) |
+| `sync-workflows.yml` fires on all PR events to `dev`, not only on merge - do not merge sync PRs in target repos until the source PR here is confirmed merged | `sync-workflows.yml` | [#36](https://github.com/tazama-lf/workflows/issues/36) |
+| `dco-check.yml` uses a reversed `git log` range - DCO sign-off is not being verified on the actual PR commits | `dco-check.yml` | [#37](https://github.com/tazama-lf/workflows/issues/37) |
+| Codacy CLI crashes with `MalformedInputException` on checkov output from multi-line YAML files - workaround: add `.checkov.yaml` with `skip-framework: github_actions` at the repo root | `codacy.yml` | [#38](https://github.com/tazama-lf/workflows/issues/38) |
 | `sbom.yml` is synced to library and rule repos but runs `docker build`, which fails in repos without a `Dockerfile` | `sbom.yml` | [#39](https://github.com/tazama-lf/workflows/issues/39) |
 | `milestone.yml` and `release.yml` use the deprecated `::set-output` syntax and `actions/checkout@v2` | `milestone.yml`, `release.yml` | [#40](https://github.com/tazama-lf/workflows/issues/40) |
-| Service repo clone URLs in `sync-workflows.yml` still use the `frmscoe` org — full migration to `tazama-lf` is pending | `sync-workflows.yml` | [#28](https://github.com/tazama-lf/workflows/issues/28) |
+| Service repo clone URLs in `sync-workflows.yml` still use the `frmscoe` org - full migration to `tazama-lf` is pending | `sync-workflows.yml` | [#28](https://github.com/tazama-lf/workflows/issues/28) |

--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ frmscoe rule repos reside in the `frmscoe` organisation and are managed by [`frm
 
 ### 7. Canonical workflow changes (this repo)
 
-Changes to this repo propagate to all 26 target repositories. This is the highest-impact SDLC path.
+Changes to this repo propagate to all 31 target repositories. This is the highest-impact SDLC path.
 
 1. **DevOps** — modifies workflow files in `.github/workflows/`; updates the corresponding `workflow-docs/` entry.
 2. **DevOps** — opens pull request targeting `dev`.
 3. **AUTO** — standard PR check suite fires against this repo.
-4. **AUTO** — `sync-workflows.yml` fires; opens `sync-workflows-update` PRs in all 31 target repos — ⚠️ [known issue #36](https://github.com/tazama-lf/workflows/issues/36): fires on PR open, not only on merge. **Do not merge sync PRs in target repos until the source PR here is confirmed merged.**
-5. **Reviewer — MANUAL** — reviews and merges the source PR to `dev` in this repo.
+4. **Reviewer — MANUAL** — reviews and merges the source PR to `dev` in this repo.
+5. **AUTO** — `sync-workflows.yml` fires on `push: dev`; opens `sync-workflows-update` PRs in all 31 target repos.
 6. **Reviewers in target repos — MANUAL** — merge `sync-workflows-update` PRs in each target repo.
 7. **DevOps — MANUAL** — applies the same changes to [`frmscoe/workflows`](https://github.com/frmscoe/workflows) via a separate PR (no automated mirror exists between the two workflow repos).
 8. **AUTO** — once merged to `dev` in `frmscoe/workflows`, its `sync-workflows.yml` fires on `push: dev` and distributes the changes to all 33 frmscoe rule repos.
@@ -183,7 +183,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `dco-check.yml` | Verify DCO Signed-off-by on commits | `pull_request` | All repos |
 | `dependency-review.yml` | Flag CVEs and licence issues in new deps | `pull_request` | All repos |
 | `dockerfile-linter.yml` | Hadolint lint of Dockerfiles | `pull_request` | All repos (no-op where no `Dockerfile` exists) |
-| `dockerhub-image-build-dual-rc.yml` | Build and push `:rc` Docker images for backend and frontend | `push: [dev]` | **Not synced** — committed directly to dual-container repos only |
+| `dockerhub-image-build-dual-rc.yml` | Build and push `:rc` Docker images for backend and frontend | `push: [dev]`, `workflow_dispatch` | **Not synced** — committed directly to dual-container repos only |
 | `dockerhub-image-build-dual.yml` | Build and push versioned Docker images for backend and frontend | `push: [main]`, `release: [published]` | **Not synced** — committed directly to dual-container repos only |
 | `dockerhub-image-build-rc.yml` | Build and push `:rc` Docker image | `push: [dev]` | Service repos only (not SPECIFIC_REPOS) |
 | `dockerhub-image-build.yml` | Build and push versioned Docker image | `push: [main]` | Service repos only (not SPECIFIC_REPOS) |
@@ -198,7 +198,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `release.yml` | Create GitHub release with auto-generated changelog as release body | `repository_dispatch: [release]` (from `milestone.yml`) | All repos |
 | `sbom.yml` | Generate SBOM from Docker image | `push: [main]` | All repos — ⚠️ [known issue #39](https://github.com/tazama-lf/workflows/issues/39) |
 | `scorecard.yml` | OSSF Scorecard supply-chain security | `push: [main,dev]`, schedule (weekly), `branch_protection_rule` | Service repos only (not `PUBLISH_REPOS`) |
-| `sync-workflows.yml` | Distribute canonical workflows to all target repos | `pull_request: [dev]`, `workflow_dispatch` | **Not synced** — canonical-only |
+| `sync-workflows.yml` | Distribute canonical workflows to all target repos | `push: [dev]`, `workflow_dispatch` | **Not synced** — canonical-only |
 | `version-check.yml` | Block PR to `main` if `package.json` version has a prerelease suffix | `pull_request: [main]` | `PUBLISH_REPOS` only |
 
 ---
@@ -221,7 +221,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `sync-workflows.yml` | Canonical-only; never distributed to target repos |
 | `node.js.yml` | Each repo maintains its own copy to allow per-repo customisation |
 
-**Full `REPOS` list (26 repos):** `relay-service`, `auth-service`, `typology-processor`, `event-director`, `event-sidecar`, `lumberjack`, `nats-utilities`, `batch-ppa`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `Full-Stack-Docker-Tazama`, `rule-executer`, `event-flow`, `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `rule-901`, `rule-902`, `tcs-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq`, `audit-lib`.
+**Full `REPOS` list (31 repos):** `relay-service`, `auth-service`, `typology-processor`, `event-director`, `event-sidecar`, `lumberjack`, `nats-utilities`, `batch-ppa`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `Full-Stack-Docker-Tazama`, `rule-executer`, `event-flow`, `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `rule-901`, `rule-902`, `tcs-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq`, `audit-lib`, `data-enrichment-service`, `event-monitoring-service`, `case-management-system`, `connection-studio`, `rule-studio`.
 
 > **frmscoe rule repos are not in this list.** They are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which syncs to 33 rule repos (`rule-001` through `rule-091`, active subset) via its own `sync-workflows.yml` triggered on `push: dev`.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Each repository in the Tazama ecosystem belongs to one class. The class determin
 
 | Class | Repos | Output | Notes |
 |-------|-------|--------|-------|
-| **Service repos** | `auth-service`, `typology-processor`, `event-director`, `event-flow`, `event-sidecar`, `lumberjack`, `nats-utilities`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor` | Docker image | Publish to Docker Hub; receive full workflow set including Docker build workflows |
+| **Service repos** | `auth-service`, `typology-processor`, `event-director`, `event-flow`, `event-sidecar`, `lumberjack`, `nats-utilities`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `data-enrichment-service`, `event-monitoring-service` | Docker image | Publish to Docker Hub; receive full workflow set including Docker build workflows |
+| **Dual-container service repos** | `case-management-system`, `connection-studio`, `rule-studio` | Docker images (backend + frontend) | Each repo produces two Docker images from `backend/` and `frontend/` subdirectories; in `SPECIFIC_REPOS` so do not receive the single-image `dockerhub-image-build*.yml`; use `dockerhub-image-build-dual*.yml` committed directly instead |
 | **Other service repos** | `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` | — | In `SPECIFIC_REPOS`; do not receive `dockerhub-image-build*.yml` |
 | **Library repos** | `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `tcs-lib`, `audit-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq` | npm package | Publish to GitHub Packages under `@tazama-lf` scope |
 | **Rule repos — tazama-lf** | `rule-901`, `rule-902` | Docker image + npm package | Also in `PUBLISH_REPOS`; use `package-rule*.yml` caller stubs for Docker builds |
@@ -99,13 +100,26 @@ Service repos produce versioned Docker images. They do not publish npm packages.
 
 ---
 
-### 3. Other service repos (no Docker CI build)
+### 3. Dual-container service repos (case-management-system, connection-studio, rule-studio)
+
+These repos follow the same PR check and release flow as standard Docker-building service repos, but each repo produces **two** Docker images - one from `backend/` and one from `frontend/` - independently versioned via their respective `package.json` files.
+
+They are listed in both `REPOS` (to receive all common workflows) and `SPECIFIC_REPOS` (to suppress the single-image `dockerhub-image-build*.yml`). The dual-image Docker workflows are **not distributed via sync** and must be committed directly to each repo:
+
+- `dockerhub-image-build-dual-rc.yml` — fires on `push: dev`; builds and pushes `tazamaorg/<repo>-backend:rc` and `tazamaorg/<repo>-frontend:rc`
+- `dockerhub-image-build-dual.yml` — fires on `push: main`; builds and pushes `tazamaorg/<repo>-backend:<version>` and `tazamaorg/<repo>-frontend:<version>`
+
+All other steps (PR checks, `sbom.yml`, `scorecard.yml`, `release.yml`, etc.) are identical to [Section 2](#2-service-repos-docker-building).
+
+---
+
+### 4. Other service repos (no Docker CI build)
 
 `relay-service`, `batch-ppa`, `rule-executer`, and `Full-Stack-Docker-Tazama` follow the same feature development and PR check flow as Docker-building service repos but do **not** receive `dockerhub-image-build*.yml` or `sbom.yml`. Their build and release processes (if any) are managed outside this workflow set.
 
 ---
 
-### 4. Rule repos — tazama-lf (rule-901, rule-902)
+### 5. Rule repos — tazama-lf (rule-901, rule-902)
 
 tazama-lf rule repos are both library repos **and** Docker image producers. They follow the full library release cycle for npm publishing (including `release-train.yml`, `publish.yml`, and `version-check.yml`) and additionally build Docker images via the `package-rule*.yml` reusable workflows.
 
@@ -117,7 +131,7 @@ tazama-lf rule repos are both library repos **and** Docker image producers. They
 
 ---
 
-### 5. Rule repos — frmscoe (rule-001 through rule-091)
+### 6. Rule repos — frmscoe (rule-001 through rule-091)
 
 frmscoe rule repos reside in the `frmscoe` organisation and are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which is a manually-maintained mirror of the relevant subset of workflows from this repo. frmscoe rule repos build Docker images via `package-rule*.yml` caller stubs (referencing `frmscoe/workflows` as the reusable workflow source) but do not use `dockerhub-image-build*.yml` or `dockerfile-linter.yml`.
 
@@ -141,14 +155,14 @@ frmscoe rule repos reside in the `frmscoe` organisation and are managed by [`frm
 
 ---
 
-### 6. Canonical workflow changes (this repo)
+### 7. Canonical workflow changes (this repo)
 
 Changes to this repo propagate to all 26 target repositories. This is the highest-impact SDLC path.
 
 1. **DevOps** — modifies workflow files in `.github/workflows/`; updates the corresponding `workflow-docs/` entry.
 2. **DevOps** — opens pull request targeting `dev`.
 3. **AUTO** — standard PR check suite fires against this repo.
-4. **AUTO** — `sync-workflows.yml` fires; opens `sync-workflows-update` PRs in all 26 target repos — ⚠️ [known issue #36](https://github.com/tazama-lf/workflows/issues/36): fires on PR open, not only on merge. **Do not merge sync PRs in target repos until the source PR here is confirmed merged.**
+4. **AUTO** — `sync-workflows.yml` fires; opens `sync-workflows-update` PRs in all 31 target repos — ⚠️ [known issue #36](https://github.com/tazama-lf/workflows/issues/36): fires on PR open, not only on merge. **Do not merge sync PRs in target repos until the source PR here is confirmed merged.**
 5. **Reviewer — MANUAL** — reviews and merges the source PR to `dev` in this repo.
 6. **Reviewers in target repos — MANUAL** — merge `sync-workflows-update` PRs in each target repo.
 7. **DevOps — MANUAL** — applies the same changes to [`frmscoe/workflows`](https://github.com/frmscoe/workflows) via a separate PR (no automated mirror exists between the two workflow repos).
@@ -169,6 +183,8 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `dco-check.yml` | Verify DCO Signed-off-by on commits | `pull_request` | All repos |
 | `dependency-review.yml` | Flag CVEs and licence issues in new deps | `pull_request` | All repos |
 | `dockerfile-linter.yml` | Hadolint lint of Dockerfiles | `pull_request` | All repos (no-op where no `Dockerfile` exists) |
+| `dockerhub-image-build-dual-rc.yml` | Build and push `:rc` Docker images for backend and frontend | `push: [dev]` | **Not synced** — committed directly to dual-container repos only |
+| `dockerhub-image-build-dual.yml` | Build and push versioned Docker images for backend and frontend | `push: [main]`, `release: [published]` | **Not synced** — committed directly to dual-container repos only |
 | `dockerhub-image-build-rc.yml` | Build and push `:rc` Docker image | `push: [dev]` | Service repos only (not SPECIFIC_REPOS) |
 | `dockerhub-image-build.yml` | Build and push versioned Docker image | `push: [main]` | Service repos only (not SPECIFIC_REPOS) |
 | `gpg-verify.yml` | Verify GPG signature on commits | `pull_request` | All repos |
@@ -193,8 +209,8 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 
 | Group | Members | Behaviour |
 |-------|---------|-----------|
-| `REPOS` | All 26 tazama-lf target repos | Receive all workflows except those explicitly excluded |
-| `SPECIFIC_REPOS` | All library repos + `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` | Skip `dockerhub-image-build.yml` and `dockerhub-image-build-rc.yml` |
+| `REPOS` | All 31 tazama-lf target repos | Receive all workflows except those explicitly excluded |
+| `SPECIFIC_REPOS` | All library repos + `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` + dual-container repos (`case-management-system`, `connection-studio`, `rule-studio`) | Skip `dockerhub-image-build.yml`, `dockerhub-image-build-rc.yml`, `dockerhub-image-build-dual.yml`, `dockerhub-image-build-dual-rc.yml` |
 | `PUBLISH_REPOS` | All library repos + `rule-901`, `rule-902` | Additionally receive `publish.yml`, `version-check.yml`, `release-train.yml`; skip `scorecard.yml` |
 | `RULE_REPOS` | `rule-901`, `rule-902` | Receive caller stubs for `package-rule*.yml` instead of the full reusable workflow definition |
 

--- a/workflow-docs/branch-target-check.md
+++ b/workflow-docs/branch-target-check.md
@@ -27,11 +27,11 @@ Enforces the feature-branch → dev → main development workflow by failing any
 
 ## Jobs
 
-### `check-source-branch` — verify PR source branch
+### `check-source-branch` - verify PR source branch
 
 **Steps:**
 
-1. `Verify PR source branch is dev or release/v<N>.*` — shell check; exits `1` with actionable message (including `gh pr edit --base dev` hint) if source branch is not `dev` or `release/v[0-9]*`
+1. `Verify PR source branch is dev or release/v<N>.*` - shell check; exits `1` with actionable message (including `gh pr edit --base dev` hint) if source branch is not `dev` or `release/v[0-9]*`
 
 ---
 
@@ -51,7 +51,7 @@ None.
 
 ## Dependencies (pinned actions)
 
-None — single run step only.
+None - single run step only.
 
 ---
 

--- a/workflow-docs/codacy.md
+++ b/workflow-docs/codacy.md
@@ -29,13 +29,13 @@ Performs a Codacy security scan of the codebase and uploads results in SARIF for
 
 ## Jobs
 
-### `codacy-security-scan` — Codacy Security Scan
+### `codacy-security-scan` - Codacy Security Scan
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` — runs Codacy CLI; outputs `results.sarif`; `max-allowed-issues: 2147483647` defers PR rejection to GitHub
-3. `github/codeql-action/upload-sarif@v3` — uploads `results.sarif` to GitHub code scanning
+1. `actions/checkout@v4` - checks out source
+2. `codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` - runs Codacy CLI; outputs `results.sarif`; `max-allowed-issues: 2147483647` defers PR rejection to GitHub
+3. `github/codeql-action/upload-sarif@v3` - uploads `results.sarif` to GitHub code scanning
 
 ---
 
@@ -60,7 +60,7 @@ Performs a Codacy security scan of the codebase and uploads results in SARIF for
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
 | `codacy/codacy-analysis-cli-action` | `562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` | v4.4.7 |
-| `github/codeql-action/upload-sarif` | tag ref `v3` | — |
+| `github/codeql-action/upload-sarif` | tag ref `v3` | - |
 
 ---
 

--- a/workflow-docs/codeql.md
+++ b/workflow-docs/codeql.md
@@ -29,16 +29,16 @@ Runs GitHub CodeQL semantic analysis on JavaScript/TypeScript source code, scann
 
 ## Jobs
 
-### `analyze` — Analyze
+### `analyze` - Analyze
 
 **Matrix:** `language: [javascript]`
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `github/codeql-action/init@v3` — initialises CodeQL toolchain for JavaScript
-3. `github/codeql-action/autobuild@v3` — automatically builds the project
-4. `github/codeql-action/analyze@v3` — performs analysis and uploads results
+1. `actions/checkout@v4` - checks out source
+2. `github/codeql-action/init@v3` - initialises CodeQL toolchain for JavaScript
+3. `github/codeql-action/autobuild@v3` - automatically builds the project
+4. `github/codeql-action/analyze@v3` - performs analysis and uploads results
 
 ---
 
@@ -60,16 +60,16 @@ None (uses default `GITHUB_TOKEN`).
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
-| `github/codeql-action/init` | tag ref `v3` | — |
-| `github/codeql-action/autobuild` | tag ref `v3` | — |
-| `github/codeql-action/analyze` | tag ref `v3` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `github/codeql-action/init` | tag ref `v3` | - |
+| `github/codeql-action/autobuild` | tag ref `v3` | - |
+| `github/codeql-action/analyze` | tag ref `v3` | - |
 
 ---
 
 ## Known Limitations / Notes
 
-- Language matrix is fixed to `javascript`; CodeQL treats JS and TS together under the `javascript` language key — no change needed for TypeScript repos.
+- Language matrix is fixed to `javascript`; CodeQL treats JS and TS together under the `javascript` language key - no change needed for TypeScript repos.
 - `dependabot[bot]` actors are excluded.
 
 ---

--- a/workflow-docs/conventional-commits.md
+++ b/workflow-docs/conventional-commits.md
@@ -27,12 +27,12 @@ Validates the PR title against the Conventional Commits specification and automa
 
 ## Jobs
 
-### `validate-pr-title` — PR Conventional Commit Validation
+### `validate-pr-title` - PR Conventional Commit Validation
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `ytanikin/PRConventionalCommits@1.1.0` — validates title; accepted types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `feat!`; applies label on match
+1. `actions/checkout@v4` - checks out source
+2. `ytanikin/PRConventionalCommits@1.1.0` - validates title; accepted types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `feat!`; applies label on match
 
 ---
 
@@ -54,8 +54,8 @@ None (uses auto-provided `GITHUB_TOKEN`).
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
-| `ytanikin/PRConventionalCommits` | tag ref `1.1.0` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `ytanikin/PRConventionalCommits` | tag ref `1.1.0` | - |
 
 ---
 

--- a/workflow-docs/dco-check.md
+++ b/workflow-docs/dco-check.md
@@ -27,13 +27,13 @@ Checks that every commit in a pull request includes a `Signed-off-by:` line, enf
 
 ## Jobs
 
-### `dco` — DCO
+### `dco` - DCO
 
 **Steps:**
 
-1. `actions/checkout@v4` — full history fetch (`fetch-depth: 0`)
-2. `Set up environment variables` — captures `BASE_BRANCH` and `HEAD_BRANCH` from PR context
-3. `Check for DCO Sign-off` — iterates commits between head and base; fails listing non-compliant SHAs
+1. `actions/checkout@v4` - full history fetch (`fetch-depth: 0`)
+2. `Set up environment variables` - captures `BASE_BRANCH` and `HEAD_BRANCH` from PR context
+3. `Check for DCO Sign-off` - iterates commits between head and base; fails listing non-compliant SHAs
 
 ---
 
@@ -55,14 +55,14 @@ None.
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
 
 ---
 
 ## Known Limitations / Notes
 
 - `dependabot[bot]` actors are excluded.
-- The `git log` range uses `origin/HEAD_BRANCH..origin/BASE_BRANCH`, which gives commits present in the base but absent from the head — the reverse of what a DCO check requires. The correct range is `origin/BASE_BRANCH..origin/HEAD_BRANCH`. This is a latent bug; the check may pass silently on PRs that contain unsigned commits.
+- The `git log` range uses `origin/HEAD_BRANCH..origin/BASE_BRANCH`, which gives commits present in the base but absent from the head - the reverse of what a DCO check requires. The correct range is `origin/BASE_BRANCH..origin/HEAD_BRANCH`. This is a latent bug; the check may pass silently on PRs that contain unsigned commits.
 
 ---
 

--- a/workflow-docs/dependency-review.md
+++ b/workflow-docs/dependency-review.md
@@ -27,12 +27,12 @@ Scans dependency manifest file changes in pull requests and blocks merging if ne
 
 ## Jobs
 
-### `dependency-review` — Dependency Review
+### `dependency-review` - Dependency Review
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `actions/dependency-review-action@v4` — reviews dependency manifests; fails PR if vulnerable versions are introduced
+1. `actions/checkout@v4` - checks out source
+2. `actions/dependency-review-action@v4` - reviews dependency manifests; fails PR if vulnerable versions are introduced
 
 ---
 
@@ -54,8 +54,8 @@ None.
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
-| `actions/dependency-review-action` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `actions/dependency-review-action` | tag ref `v4` | - |
 
 ---
 

--- a/workflow-docs/dockerfile-linter.md
+++ b/workflow-docs/dockerfile-linter.md
@@ -29,13 +29,13 @@ Lints `Dockerfile` using Hadolint, a Haskell-based Dockerfile linter that enforc
 
 ## Jobs
 
-### `hadolint` — Run hadolint scanning
+### `hadolint` - Run hadolint scanning
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183` — lints `./Dockerfile`; outputs `hadolint-results.sarif`; `no-fail: true` allows SARIF generation even on findings
-3. `github/codeql-action/upload-sarif@v3` — uploads SARIF to GitHub code scanning
+1. `actions/checkout@v4` - checks out source
+2. `hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183` - lints `./Dockerfile`; outputs `hadolint-results.sarif`; `no-fail: true` allows SARIF generation even on findings
+3. `github/codeql-action/upload-sarif@v3` - uploads SARIF to GitHub code scanning
 
 ---
 
@@ -49,7 +49,7 @@ None.
 
 | Group | Behaviour |
 |-------|----------|
-| All `REPOS` | Receives this file — a no-op if the repo has no `Dockerfile` |
+| All `REPOS` | Receives this file - a no-op if the repo has no `Dockerfile` |
 
 ---
 
@@ -57,9 +57,9 @@ None.
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
-| `hadolint/hadolint-action` | `f988afea3da57ee48710a9795b6bb677cc901183` | — |
-| `github/codeql-action/upload-sarif` | tag ref `v3` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `hadolint/hadolint-action` | `f988afea3da57ee48710a9795b6bb677cc901183` | - |
+| `github/codeql-action/upload-sarif` | tag ref `v3` | - |
 
 ---
 

--- a/workflow-docs/dockerhub-image-build-dual-rc.md
+++ b/workflow-docs/dockerhub-image-build-dual-rc.md
@@ -28,29 +28,29 @@ Builds two Docker images - one for the `backend` subdirectory and one for the `f
 
 ## Jobs
 
-### `push_backend_rc` — Push backend RC Docker image to Docker Hub
+### `push_backend_rc` - Push backend RC Docker image to Docker Hub
 
 **Steps:**
 
-1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
-2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
-3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
-4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-backend`
-5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./backend` context and `./backend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
-6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates local build attestation (`push-to-registry: false` — RC builds are not published to the Sigstore transparency log)
-7. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` - checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
+3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-backend`
+5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` - builds from `./backend` context and `./backend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` - generates local build attestation (`push-to-registry: false` - RC builds are not published to the Sigstore transparency log)
+7. `Send Slack Notification` - posts to `SLACK_WEBHOOK_URL`
 
-### `push_frontend_rc` — Push frontend RC Docker image to Docker Hub
+### `push_frontend_rc` - Push frontend RC Docker image to Docker Hub
 
 **Steps:**
 
-1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
-2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
-3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
-4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-frontend`
-5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./frontend` context and `./frontend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
-6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates local build attestation (`push-to-registry: false` — RC builds are not published to the Sigstore transparency log)
-7. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` - checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
+3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-frontend`
+5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` - builds from `./frontend` context and `./frontend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` - generates local build attestation (`push-to-registry: false` - RC builds are not published to the Sigstore transparency log)
+7. `Send Slack Notification` - posts to `SLACK_WEBHOOK_URL`
 
 ---
 
@@ -69,8 +69,8 @@ Builds two Docker images - one for the `backend` subdirectory and one for the `f
 
 | Group | Behaviour |
 |-------|-----------|
-| `REPOS` (service repos) | Listed in `REPOS` but also in `SPECIFIC_REPOS` — **dual-container repos are in both lists** |
-| `SPECIFIC_REPOS` | **Excluded via `SPECIFIC_FILES`** — `dockerhub-image-build-dual-rc.yml` is listed in `SPECIFIC_FILES` and therefore not copied to repos in `SPECIFIC_REPOS` |
+| `REPOS` (service repos) | Listed in `REPOS` but also in `SPECIFIC_REPOS` - **dual-container repos are in both lists** |
+| `SPECIFIC_REPOS` | **Excluded via `SPECIFIC_FILES`** - `dockerhub-image-build-dual-rc.yml` is listed in `SPECIFIC_FILES` and therefore not copied to repos in `SPECIFIC_REPOS` |
 
 > This workflow is **not distributed via sync**. It must be committed directly to each dual-container repo. See [Repository Overrides](#repository-overrides) below.
 

--- a/workflow-docs/dockerhub-image-build-dual-rc.md
+++ b/workflow-docs/dockerhub-image-build-dual-rc.md
@@ -1,0 +1,107 @@
+# `dockerhub-image-build-dual-rc.yml`
+
+## Purpose
+
+Builds two Docker images - one for the `backend` subdirectory and one for the `frontend` subdirectory - and pushes each to Docker Hub with a floating `:rc` tag whenever code is merged to `dev`. Provides testable release-candidate images for both components without overwriting the stable production tags. For repositories whose source tree contains separate `backend/` and `frontend/` applications that are independently versioned and published as separate Docker images.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[dev]` |
+| `workflow_dispatch` | manual |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~5–8 min per job (jobs run in parallel) |
+| Concurrency | none |
+| Permissions | `packages: write`, `contents: read`, `attestations: write`, `id-token: write` |
+
+---
+
+## Jobs
+
+### `push_backend_rc` — Push backend RC Docker image to Docker Hub
+
+**Steps:**
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
+3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-backend`
+5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./backend` context and `./backend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates local build attestation (`push-to-registry: false` — RC builds are not published to the Sigstore transparency log)
+7. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+
+### `push_frontend_rc` — Push frontend RC Docker image to Docker Hub
+
+**Steps:**
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
+3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-frontend`
+5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./frontend` context and `./frontend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates local build attestation (`push-to-registry: false` — RC builds are not published to the Sigstore transparency log)
+7. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `DOCKER_USERNAME` | org | Docker Hub login |
+| `DOCKER_PASSWORD` | org | Docker Hub password |
+| `GH_TOKEN` | org | `npm ci` build secret for private package access |
+| `SLACK_WEBHOOK_URL` | org | Slack notification |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `REPOS` (service repos) | Listed in `REPOS` but also in `SPECIFIC_REPOS` — **dual-container repos are in both lists** |
+| `SPECIFIC_REPOS` | **Excluded via `SPECIFIC_FILES`** — `dockerhub-image-build-dual-rc.yml` is listed in `SPECIFIC_FILES` and therefore not copied to repos in `SPECIFIC_REPOS` |
+
+> This workflow is **not distributed via sync**. It must be committed directly to each dual-container repo. See [Repository Overrides](#repository-overrides) below.
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v4 |
+| `docker/login-action` | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v3 |
+| `docker/metadata-action` | `030e881283bb7a6894de51c315a6bfe6a94e05cf` | v5 |
+| `docker/build-push-action` | `d08e5c354a6adb9ed34480a06d141179aa583294` | v6 |
+| `actions/attest-build-provenance` | `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` | v2 |
+
+---
+
+## Known Limitations / Notes
+
+- The two jobs (`push_backend_rc` and `push_frontend_rc`) run in parallel and are independent. A failure in one does not cancel the other.
+- The `:rc` tag is a floating pointer overwritten on every push to `dev`. Use a version-pinned prerelease tag for reproducible deployments.
+- `dependabot[bot]` actors are excluded from both jobs.
+
+---
+
+## Repository Overrides
+
+This workflow is **not distributed by sync**. The dual-container repos listed below maintain their own copy committed directly to the repo.
+
+| Repository | Reason |
+|-----------|--------|
+| `case-management-system` | Dual-container repo (backend + frontend); canonical single-image workflow cannot represent this |
+| `connection-studio` | Dual-container repo (backend + frontend); canonical single-image workflow cannot represent this |
+| `rule-studio` | Dual-container repo (backend + frontend); canonical single-image workflow cannot represent this |

--- a/workflow-docs/dockerhub-image-build-dual.md
+++ b/workflow-docs/dockerhub-image-build-dual.md
@@ -1,0 +1,109 @@
+# `dockerhub-image-build-dual.yml`
+
+## Purpose
+
+Builds two Docker images - one for the `backend` subdirectory and one for the `frontend` subdirectory - and pushes each to Docker Hub with a version tag derived from the respective subdirectory's `package.json`. Fires whenever a release is published or code is merged to `main`. For repositories whose source tree contains separate `backend/` and `frontend/` applications that are independently versioned and published as separate Docker images.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[main]` |
+| `release` | types: `[published]` |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~5–8 min per job (jobs run in parallel) |
+| Concurrency | none |
+| Permissions | `packages: write`, `contents: read`, `attestations: write`, `id-token: write` |
+
+---
+
+## Jobs
+
+### `push_backend` — Push backend Docker image to Docker Hub
+
+**Steps:**
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
+3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `Get backend package version` — reads `VERSION` from `backend/package.json` via `node -p`; sets step output `VERSION`
+5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`; image name: `tazamaorg/<REPO_NAME>-backend`
+6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./backend` context and `./backend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates and pushes build attestation to Sigstore transparency log
+8. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+
+### `push_frontend` — Push frontend Docker image to Docker Hub
+
+**Steps:**
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
+3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `Get frontend package version` — reads `VERSION` from `frontend/package.json` via `node -p`; sets step output `VERSION`
+5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`; image name: `tazamaorg/<REPO_NAME>-frontend`
+6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./frontend` context and `./frontend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates and pushes build attestation to Sigstore transparency log
+8. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `DOCKER_USERNAME` | org | Docker Hub login |
+| `DOCKER_PASSWORD` | org | Docker Hub password |
+| `GH_TOKEN` | org | `npm ci` build secret for private package access |
+| `SLACK_WEBHOOK_URL` | org | Slack notification |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `REPOS` (service repos) | Listed in `REPOS` but also in `SPECIFIC_REPOS` — **dual-container repos are in both lists** |
+| `SPECIFIC_REPOS` | **Excluded via `SPECIFIC_FILES`** — `dockerhub-image-build-dual.yml` is listed in `SPECIFIC_FILES` and therefore not copied to repos in `SPECIFIC_REPOS` |
+
+> This workflow is **not distributed via sync**. It must be committed directly to each dual-container repo. See [Repository Overrides](#repository-overrides) below.
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v4 |
+| `docker/login-action` | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v3 |
+| `docker/metadata-action` | `030e881283bb7a6894de51c315a6bfe6a94e05cf` | v5 |
+| `docker/build-push-action` | `d08e5c354a6adb9ed34480a06d141179aa583294` | v6 |
+| `actions/attest-build-provenance` | `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` | v2 |
+
+---
+
+## Known Limitations / Notes
+
+- The two jobs (`push_backend` and `push_frontend`) run in parallel and are independent. A failure in one does not cancel the other.
+- Backend and frontend versions are read from their respective `package.json` files and may differ. There is no check that they are consistent.
+- `dependabot[bot]` actors are excluded from both jobs.
+
+---
+
+## Repository Overrides
+
+This workflow is **not distributed by sync**. The dual-container repos listed below maintain their own copy committed directly to the repo.
+
+| Repository | Reason |
+|-----------|--------|
+| `case-management-system` | Dual-container repo (backend + frontend); canonical single-image workflow cannot represent this |
+| `connection-studio` | Dual-container repo (backend + frontend); canonical single-image workflow cannot represent this |
+| `rule-studio` | Dual-container repo (backend + frontend); canonical single-image workflow cannot represent this |

--- a/workflow-docs/dockerhub-image-build-dual.md
+++ b/workflow-docs/dockerhub-image-build-dual.md
@@ -28,31 +28,31 @@ Builds two Docker images - one for the `backend` subdirectory and one for the `f
 
 ## Jobs
 
-### `push_backend` — Push backend Docker image to Docker Hub
+### `push_backend` - Push backend Docker image to Docker Hub
 
 **Steps:**
 
-1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
-2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
-3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
-4. `Get backend package version` — reads `VERSION` from `backend/package.json` via `node -p`; sets step output `VERSION`
-5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`; image name: `tazamaorg/<REPO_NAME>-backend`
-6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./backend` context and `./backend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
-7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates and pushes build attestation to Sigstore transparency log
-8. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` - checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
+3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `Get backend package version` - reads `VERSION` from `backend/package.json` via `node -p`; sets step output `VERSION`
+5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`; image name: `tazamaorg/<REPO_NAME>-backend`
+6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` - builds from `./backend` context and `./backend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` - generates and pushes build attestation to Sigstore transparency log
+8. `Send Slack Notification` - posts to `SLACK_WEBHOOK_URL`
 
-### `push_frontend` — Push frontend Docker image to Docker Hub
+### `push_frontend` - Push frontend Docker image to Docker Hub
 
 **Steps:**
 
-1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source
-2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
-3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
-4. `Get frontend package version` — reads `VERSION` from `frontend/package.json` via `node -p`; sets step output `VERSION`
-5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`; image name: `tazamaorg/<REPO_NAME>-frontend`
-6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds from `./frontend` context and `./frontend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
-7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates and pushes build attestation to Sigstore transparency log
-8. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` - checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
+3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `Get frontend package version` - reads `VERSION` from `frontend/package.json` via `node -p`; sets step output `VERSION`
+5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`; image name: `tazamaorg/<REPO_NAME>-frontend`
+6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` - builds from `./frontend` context and `./frontend/Dockerfile`; pushes image; passes `GH_TOKEN` as build secret
+7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` - generates and pushes build attestation to Sigstore transparency log
+8. `Send Slack Notification` - posts to `SLACK_WEBHOOK_URL`
 
 ---
 
@@ -71,8 +71,8 @@ Builds two Docker images - one for the `backend` subdirectory and one for the `f
 
 | Group | Behaviour |
 |-------|-----------|
-| `REPOS` (service repos) | Listed in `REPOS` but also in `SPECIFIC_REPOS` — **dual-container repos are in both lists** |
-| `SPECIFIC_REPOS` | **Excluded via `SPECIFIC_FILES`** — `dockerhub-image-build-dual.yml` is listed in `SPECIFIC_FILES` and therefore not copied to repos in `SPECIFIC_REPOS` |
+| `REPOS` (service repos) | Listed in `REPOS` but also in `SPECIFIC_REPOS` - **dual-container repos are in both lists** |
+| `SPECIFIC_REPOS` | **Excluded via `SPECIFIC_FILES`** - `dockerhub-image-build-dual.yml` is listed in `SPECIFIC_FILES` and therefore not copied to repos in `SPECIFIC_REPOS` |
 
 > This workflow is **not distributed via sync**. It must be committed directly to each dual-container repo. See [Repository Overrides](#repository-overrides) below.
 

--- a/workflow-docs/dockerhub-image-build-rc.md
+++ b/workflow-docs/dockerhub-image-build-rc.md
@@ -28,17 +28,17 @@ Builds a Docker image and pushes it to Docker Hub with a floating `:rc` tag when
 
 ## Jobs
 
-### `push_to_registry` — Push Docker image to Docker Hub
+### `push_to_registry` - Push Docker image to Docker Hub
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
-3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
-4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=rc`
-5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds and pushes image; passes `GH_TOKEN` as build arg for private package access
-6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates local build attestation (`push-to-registry: false` — RC builds are not published to the Sigstore transparency log)
-7. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@v4` - checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
+3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=rc`
+5. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` - builds and pushes image; passes `GH_TOKEN` as build arg for private package access
+6. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` - generates local build attestation (`push-to-registry: false` - RC builds are not published to the Sigstore transparency log)
+7. `Send Slack Notification` - posts to `SLACK_WEBHOOK_URL`
 
 ---
 
@@ -58,7 +58,7 @@ Builds a Docker image and pushes it to Docker Hub with a floating `:rc` tag when
 | Group | Behaviour |
 |-------|-----------|
 | `REPOS` (service repos) | Receives this file |
-| `SPECIFIC_REPOS` | **Excluded** — library/non-Docker repos do not build Docker images |
+| `SPECIFIC_REPOS` | **Excluded** - library/non-Docker repos do not build Docker images |
 
 ---
 
@@ -66,7 +66,7 @@ Builds a Docker image and pushes it to Docker Hub with a floating `:rc` tag when
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|--------------|
-| `actions/checkout` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
 | `docker/login-action` | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v3 |
 | `docker/metadata-action` | `030e881283bb7a6894de51c315a6bfe6a94e05cf` | v5 |
 | `docker/build-push-action` | `d08e5c354a6adb9ed34480a06d141179aa583294` | v6 |

--- a/workflow-docs/dockerhub-image-build.md
+++ b/workflow-docs/dockerhub-image-build.md
@@ -28,18 +28,18 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 
 ## Jobs
 
-### `push_to_registry` — Push Docker image to Docker Hub
+### `push_to_registry` - Push Docker image to Docker Hub
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` — authenticates to Docker Hub
-3. `Set ENV variables` — derives `REPO_NAME` from `GITHUB_REPOSITORY`
-4. `Get package version` — reads `VERSION` from `package.json` via `node -p`; sets step output `VERSION`
-5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` — generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`
-6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` — builds and pushes image; passes `GH_TOKEN` as build arg
-7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` — generates and pushes build attestation to Sigstore transparency log
-8. `Send Slack Notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@v4` - checks out source
+2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
+3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
+4. `Get package version` - reads `VERSION` from `package.json` via `node -p`; sets step output `VERSION`
+5. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=${{ steps.pkg_version.outputs.VERSION }}`
+6. `docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294` - builds and pushes image; passes `GH_TOKEN` as build arg
+7. `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` - generates and pushes build attestation to Sigstore transparency log
+8. `Send Slack Notification` - posts to `SLACK_WEBHOOK_URL`
 
 ---
 
@@ -59,7 +59,7 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 | Group | Behaviour |
 |-------|----------|
 | `REPOS` (service repos) | Receives this file |
-| `SPECIFIC_REPOS` | **Excluded** — library/non-Docker repos do not build Docker images |
+| `SPECIFIC_REPOS` | **Excluded** - library/non-Docker repos do not build Docker images |
 
 ---
 
@@ -67,7 +67,7 @@ Builds a Docker image and pushes it to Docker Hub with a version tag derived fro
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
 | `docker/login-action` | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v3 |
 | `docker/metadata-action` | `030e881283bb7a6894de51c315a6bfe6a94e05cf` | v5 |
 | `docker/build-push-action` | `d08e5c354a6adb9ed34480a06d141179aa583294` | v6 |

--- a/workflow-docs/docs-template.md
+++ b/workflow-docs/docs-template.md
@@ -30,12 +30,12 @@ One or two sentences describing what this workflow does and why it exists.
 
 ## Jobs
 
-### `<job-id>` — <short description>
+### `<job-id>` - <short description>
 
 **Steps:**
 
-1. `actions/checkout@<sha>` — checks out source
-2. `<step name>` — <what it does>
+1. `actions/checkout@<sha>` - checks out source
+2. `<step name>` - <what it does>
 3. ...
 
 **Outputs:** _(if any)_
@@ -60,8 +60,8 @@ One or two sentences describing what this workflow does and why it exists.
 | Group | Behaviour |
 |-------|-----------|
 | `REPOS` | Receives this file |
-| `SPECIFIC_REPOS` | **Excluded** — reason |
-| `PUBLISH_REPOS` | **Excluded** — reason |
+| `SPECIFIC_REPOS` | **Excluded** - reason |
+| `PUBLISH_REPOS` | **Excluded** - reason |
 
 ---
 

--- a/workflow-docs/gpg-verify.md
+++ b/workflow-docs/gpg-verify.md
@@ -27,13 +27,13 @@ Verifies that every commit in a pull request has a valid GPG signature using the
 
 ## Jobs
 
-### `gpg-verify` — GPG Verify
+### `gpg-verify` - GPG Verify
 
 **Steps:**
 
-1. `actions/checkout@v4` — full history fetch (`fetch-depth: 0`)
-2. `Set up environment variables` — captures `PR_HEAD_REF`, `PR_BASE_REF`, `GITHUB_TOKEN`, `GITHUB_REPOSITORY`
-3. `Check GPG verification status` — iterates commits via `git log origin/${PR_BASE_REF}..origin/${PR_HEAD_REF}`; queries `/repos/:repo/commits/:sha` for each and checks `.commit.verification.verified`; fails if any commit is unverified
+1. `actions/checkout@v4` - full history fetch (`fetch-depth: 0`)
+2. `Set up environment variables` - captures `PR_HEAD_REF`, `PR_BASE_REF`, `GITHUB_TOKEN`, `GITHUB_REPOSITORY`
+3. `Check GPG verification status` - iterates commits via `git log origin/${PR_BASE_REF}..origin/${PR_HEAD_REF}`; queries `/repos/:repo/commits/:sha` for each and checks `.commit.verification.verified`; fails if any commit is unverified
 
 ---
 
@@ -55,14 +55,14 @@ None (uses auto-provided `GITHUB_TOKEN`).
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
 
 ---
 
 ## Known Limitations / Notes
 
-- `dependabot[bot]`, `dependabot-preview[bot]`, and `github-actions[bot]` actors are excluded — these automated actors do not have GPG keys and will never produce signed commits.
-- An empty commit range (e.g. no new commits on the head branch) is handled gracefully — the step exits 0 without failing.
+- `dependabot[bot]`, `dependabot-preview[bot]`, and `github-actions[bot]` actors are excluded - these automated actors do not have GPG keys and will never produce signed commits.
+- An empty commit range (e.g. no new commits on the head branch) is handled gracefully - the step exits 0 without failing.
 - GPG verification is checked via the GitHub commit API (`.commit.verification.verified`), which uses the committer's GitHub-linked public key. Local GPG keyrings on the runner are not required.
 
 ---

--- a/workflow-docs/milestone.md
+++ b/workflow-docs/milestone.md
@@ -27,14 +27,14 @@ Closes a GitHub milestone and triggers the `release.yml` workflow via `repositor
 
 ## Jobs
 
-### `close_milestone` — close milestone and trigger release
+### `close_milestone` - close milestone and trigger release
 
 **Steps:**
 
-1. `actions/checkout@v2` — checks out source
-2. `Set up environment variables` — sets `ACCESS_TOKEN`, `MILESTONE_NUMBER`, `API_URL`
-3. `Close Milestone` — calls `PATCH /repos/:repo/milestones/:number` with `{"state": "closed"}`
-4. `Trigger Release Workflow` — `peter-evans/repository-dispatch@v1` fires `release` event with `milestone_number` payload
+1. `actions/checkout@v2` - checks out source
+2. `Set up environment variables` - sets `ACCESS_TOKEN`, `MILESTONE_NUMBER`, `API_URL`
+3. `Close Milestone` - calls `PATCH /repos/:repo/milestones/:number` with `{"state": "closed"}`
+4. `Trigger Release Workflow` - `peter-evans/repository-dispatch@v1` fires `release` event with `milestone_number` payload
 
 ---
 
@@ -56,15 +56,15 @@ None (uses auto-provided `GITHUB_TOKEN`).
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v2` | — |
-| `peter-evans/repository-dispatch` | tag ref `v1` | — |
+| `actions/checkout` | tag ref `v2` | - |
+| `peter-evans/repository-dispatch` | tag ref `v1` | - |
 
 ---
 
 ## Known Limitations / Notes
 
 - `dependabot[bot]` actors are excluded.
-- Uses `actions/checkout@v2` — should be upgraded to `v4` to align with all other workflows.
+- Uses `actions/checkout@v2` - should be upgraded to `v4` to align with all other workflows.
 - `peter-evans/repository-dispatch@v1` is not pinned to a SHA; should be pinned per GitHub hardening recommendations.
 - The milestone is closed before the release workflow is confirmed to have started; if the dispatch fails, the milestone remains closed without a release created.
 

--- a/workflow-docs/njsscan.md
+++ b/workflow-docs/njsscan.md
@@ -29,13 +29,13 @@ Runs the njsscan (nodejsscan) static security scanner against the Node.js codeba
 
 ## Jobs
 
-### `njsscan` — njsscan code scanning
+### `njsscan` - njsscan code scanning
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81` — scans `.`; outputs `results.sarif`; `|| true` ensures SARIF is always generated even when issues are found
-3. `github/codeql-action/upload-sarif@v3` — uploads `results.sarif`
+1. `actions/checkout@v4` - checks out source
+2. `ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81` - scans `.`; outputs `results.sarif`; `|| true` ensures SARIF is always generated even when issues are found
+3. `github/codeql-action/upload-sarif@v3` - uploads `results.sarif`
 
 ---
 
@@ -57,9 +57,9 @@ None.
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
-| `ajinabraham/njsscan-action` | `d58d8b2f26322cd35a9efb8003baac517f226d81` | — |
-| `github/codeql-action/upload-sarif` | tag ref `v3` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `ajinabraham/njsscan-action` | `d58d8b2f26322cd35a9efb8003baac517f226d81` | - |
+| `github/codeql-action/upload-sarif` | tag ref `v3` | - |
 
 ---
 

--- a/workflow-docs/nodejs.md
+++ b/workflow-docs/nodejs.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Node.js CI pipeline with three parallel jobs — build, lint, and test — running against Node.js 20. Validates that the project compiles, passes linting rules, and all tests pass on every push and pull request to `dev` and `main`.
+Node.js CI pipeline with three parallel jobs - build, lint, and test - running against Node.js 20. Validates that the project compiles, passes linting rules, and all tests pass on every push and pull request to `dev` and `main`.
 
 ---
 
@@ -41,21 +41,21 @@ Node.js CI pipeline with three parallel jobs — build, lint, and test — runni
 
 ## Jobs
 
-### `build` — run build
+### `build` - run build
 
 1. `actions/checkout@v4`
-2. `actions/setup-node@v4` — Node 20, npm cache, registry and scope
+2. `actions/setup-node@v4` - Node 20, npm cache, registry and scope
 3. `npm ci`
 4. `npm run build`
 
-### `lint` — check style
+### `lint` - check style
 
 1. `actions/checkout@v4`
 2. `actions/setup-node@v4`
 3. `npm ci`
 4. `npm run lint`
 
-### `test` — check tests
+### `test` - check tests
 
 1. `actions/checkout@v4`
 2. `actions/setup-node@v4`
@@ -76,7 +76,7 @@ Node.js CI pipeline with three parallel jobs — build, lint, and test — runni
 
 | Group | Behaviour |
 |-------|----------|
-| **All repos** | **Excluded from sync** — `node.js.yml` is explicitly removed before the sync bundle is assembled; every repo maintains its own copy |
+| **All repos** | **Excluded from sync** - `node.js.yml` is explicitly removed before the sync bundle is assembled; every repo maintains its own copy |
 
 ---
 
@@ -84,8 +84,8 @@ Node.js CI pipeline with three parallel jobs — build, lint, and test — runni
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
-| `actions/setup-node` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `actions/setup-node` | tag ref `v4` | - |
 
 ---
 
@@ -99,4 +99,4 @@ Node.js CI pipeline with three parallel jobs — build, lint, and test — runni
 
 ## Repository Overrides
 
-Not applicable — this workflow is not synced; every repo maintains its own copy. Some repos previously had a `bench` job included in this file; that job is being removed via separate PRs.
+Not applicable - this workflow is not synced; every repo maintains its own copy. Some repos previously had a `bench` job included in this file; that job is being removed via separate PRs.

--- a/workflow-docs/package-rule-rc.md
+++ b/workflow-docs/package-rule-rc.md
@@ -43,15 +43,15 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out rule repo source
-2. `actions/setup-node@v4` — Node 20
-3. `Read rule version from package.json` — reads `version`; fails if version is NOT a prerelease (`-` suffix required — guards against RC build running on a stable version)
-4. `Clone Rule Executer repository (dev branch)` — clones `tazama-lf/rule-executer@dev`
-5. `Prepare rule-executer-<N>` — copies cloned directory
-6. `Modify package.json and Dockerfile for rule <N>` — uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
-7. `Install dependencies` — `npm install` in the patched directory (uses `npm install` rather than `npm ci` because the preceding `sed` step modifies `package.json`, invalidating the lockfile)
-8. `Build and push RC Docker image` — builds once; tags with `VERSION` and `:rc`; pushes both
-9. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@v4` - checks out rule repo source
+2. `actions/setup-node@v4` - Node 20
+3. `Read rule version from package.json` - reads `version`; fails if version is NOT a prerelease (`-` suffix required - guards against RC build running on a stable version)
+4. `Clone Rule Executer repository (dev branch)` - clones `tazama-lf/rule-executer@dev`
+5. `Prepare rule-executer-<N>` - copies cloned directory
+6. `Modify package.json and Dockerfile for rule <N>` - uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
+7. `Install dependencies` - `npm install` in the patched directory (uses `npm install` rather than `npm ci` because the preceding `sed` step modifies `package.json`, invalidating the lockfile)
+8. `Build and push RC Docker image` - builds once; tags with `VERSION` and `:rc`; pushes both
+9. `Send Slack notification` - posts to `SLACK_WEBHOOK_URL`
 
 ---
 
@@ -70,7 +70,7 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 
 | Group | Behaviour |
 |-------|-----------|
-| `RULE_REPOS` (`rule-901`, `rule-902`) | Receives a **caller stub** — the canonical reusable definition lives only in `tazama-lf/workflows` |
+| `RULE_REPOS` (`rule-901`, `rule-902`) | Receives a **caller stub** - the canonical reusable definition lives only in `tazama-lf/workflows` |
 | All other repos | **Not distributed** |
 
 ---
@@ -79,8 +79,8 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|--------------|
-| `actions/checkout` | tag ref `v4` | — |
-| `actions/setup-node` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `actions/setup-node` | tag ref `v4` | - |
 
 ---
 

--- a/workflow-docs/package-rule.md
+++ b/workflow-docs/package-rule.md
@@ -43,15 +43,15 @@ Called from a caller stub `package-rule.yml` in each rule repo rather than being
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out rule repo source
-2. `actions/setup-node@v4` — Node 20
-3. `Read rule version from package.json` — reads `version`; fails if version is a prerelease (guards against stable build running on a prerelease version)
-4. `Clone Rule Executer repository (main branch)` — clones `tazama-lf/rule-executer@main`
-5. `Prepare rule-executer-<N>` — copies cloned directory
-6. `Modify package.json and Dockerfile for rule <N>` — uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
-7. `Install dependencies` — `npm install` in the patched directory (uses `npm install` rather than `npm ci` because the preceding `sed` step modifies `package.json`, invalidating the lockfile)
-8. `Build and push stable Docker image` — builds once; tags with `VERSION` and `:latest`; pushes both
-9. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@v4` - checks out rule repo source
+2. `actions/setup-node@v4` - Node 20
+3. `Read rule version from package.json` - reads `version`; fails if version is a prerelease (guards against stable build running on a prerelease version)
+4. `Clone Rule Executer repository (main branch)` - clones `tazama-lf/rule-executer@main`
+5. `Prepare rule-executer-<N>` - copies cloned directory
+6. `Modify package.json and Dockerfile for rule <N>` - uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
+7. `Install dependencies` - `npm install` in the patched directory (uses `npm install` rather than `npm ci` because the preceding `sed` step modifies `package.json`, invalidating the lockfile)
+8. `Build and push stable Docker image` - builds once; tags with `VERSION` and `:latest`; pushes both
+9. `Send Slack notification` - posts to `SLACK_WEBHOOK_URL`
 
 ---
 
@@ -70,7 +70,7 @@ Called from a caller stub `package-rule.yml` in each rule repo rather than being
 
 | Group | Behaviour |
 |-------|-----------|
-| `RULE_REPOS` (`rule-901`, `rule-902`) | Receives a **caller stub** — the canonical reusable definition lives only in `tazama-lf/workflows` |
+| `RULE_REPOS` (`rule-901`, `rule-902`) | Receives a **caller stub** - the canonical reusable definition lives only in `tazama-lf/workflows` |
 | All other repos | **Not distributed** |
 
 ---
@@ -79,15 +79,15 @@ Called from a caller stub `package-rule.yml` in each rule repo rather than being
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|--------------|
-| `actions/checkout` | tag ref `v4` | — |
-| `actions/setup-node` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `actions/setup-node` | tag ref `v4` | - |
 
 ---
 
 ## Known Limitations / Notes
 
 - `dependabot[bot]` actors are excluded.
-- Fails explicitly if version IS a prerelease — the `version-check.yml` guard on `main` PRs provides a second line of defence for library repos, but this redundant check prevents an accidental stable-build run if branch protection is bypassed.
+- Fails explicitly if version IS a prerelease - the `version-check.yml` guard on `main` PRs provides a second line of defence for library repos, but this redundant check prevents an accidental stable-build run if branch protection is bypassed.
 - The `checkov:skip=CKV_GHA_7` annotation suppresses a false-positive: the `version` input variable is emitted by a `node -p` read of `package.json` and controls only the Docker tag, not the build artifact source.
 
 ---

--- a/workflow-docs/publish.md
+++ b/workflow-docs/publish.md
@@ -35,13 +35,13 @@ Publishes a Node.js package to GitHub Packages (`@tazama-lf` scope). Prerelease 
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source (token: `GH_TOKEN_LIB`)
-2. `actions/setup-node@v4` — Node 20, GitHub Packages registry, `@tazama-lf` scope
-3. `Set up npm authentication` — appends `_authToken` to `~/.npmrc`
-4. `npm ci` — installs dependencies
-5. `npm run build` — compiles package
-6. `Publish package` — reads version from `package.json`; if version contains `-` publishes with `--tag rc`; otherwise publishes with implicit `latest`
-7. `Send Slack notification` — posts to `SLACK_WEBHOOK_URL`
+1. `actions/checkout@v4` - checks out source (token: `GH_TOKEN_LIB`)
+2. `actions/setup-node@v4` - Node 20, GitHub Packages registry, `@tazama-lf` scope
+3. `Set up npm authentication` - appends `_authToken` to `~/.npmrc`
+4. `npm ci` - installs dependencies
+5. `npm run build` - compiles package
+6. `Publish package` - reads version from `package.json`; if version contains `-` publishes with `--tag rc`; otherwise publishes with implicit `latest`
+7. `Send Slack notification` - posts to `SLACK_WEBHOOK_URL`
 
 ---
 
@@ -59,7 +59,7 @@ Publishes a Node.js package to GitHub Packages (`@tazama-lf` scope). Prerelease 
 | Group | Behaviour |
 |-------|-----------|
 | `PUBLISH_REPOS` | Receives this file |
-| All service repos (non-`PUBLISH_REPOS`) | **Excluded** — service repos publish Docker images, not npm packages |
+| All service repos (non-`PUBLISH_REPOS`) | **Excluded** - service repos publish Docker images, not npm packages |
 
 ---
 
@@ -67,8 +67,8 @@ Publishes a Node.js package to GitHub Packages (`@tazama-lf` scope). Prerelease 
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|--------------|
-| `actions/checkout` | tag ref `v4` | — |
-| `actions/setup-node` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `actions/setup-node` | tag ref `v4` | - |
 
 ---
 

--- a/workflow-docs/release-train.md
+++ b/workflow-docs/release-train.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Prepares a library release PR from `dev` → `main`. Given a target stable version, it validates the input, resolves all internal `@tazama-lf`/`@frmscoe` rc dependencies to their latest stable equivalents, bumps `package.json`, regenerates `package-lock.json`, then creates a `release/v<N>` branch and opens a PR — all via the GitHub API so that commits are Verified and satisfy branch protection.
+Prepares a library release PR from `dev` → `main`. Given a target stable version, it validates the input, resolves all internal `@tazama-lf`/`@frmscoe` rc dependencies to their latest stable equivalents, bumps `package.json`, regenerates `package-lock.json`, then creates a `release/v<N>` branch and opens a PR - all via the GitHub API so that commits are Verified and satisfy branch protection.
 
 ---
 
@@ -10,7 +10,7 @@ Prepares a library release PR from `dev` → `main`. Given a target stable versi
 
 | Event | Conditions |
 |-------|-----------|
-| `workflow_dispatch` | input: `version` (required, clean semver `X.Y.Z` — no prerelease suffix) |
+| `workflow_dispatch` | input: `version` (required, clean semver `X.Y.Z` - no prerelease suffix) |
 
 ---
 
@@ -33,15 +33,15 @@ Prepares a library release PR from `dev` → `main`. Given a target stable versi
 
 **Steps:**
 
-1. `Validate version input` — rejects prerelease suffixes and non-`X.Y.Z` strings
-2. `actions/checkout@v4` — checks out `dev` branch (token: `GH_TOKEN_LIB`)
-3. `actions/setup-node@v4` — Node 20, GitHub Packages registry, `@tazama-lf` scope
-4. `Add @frmscoe registry scope` — appends registry line to `~/.npmrc`
-5. `Resolve internal rc dependencies to stable` — iterates `dependencies`, `devDependencies`, `peerDependencies`; resolves pinned-rc and range-with-rc patterns; fails if `dist-tags.latest` is still a prerelease
-6. `Update version in package.json` — writes the workflow input version
-7. `Regenerate package-lock.json` — runs `npm install --package-lock-only`
-8. `Commit and push to release branch via GitHub API` — creates/resets `release/v<N>` branch at current dev HEAD; builds tree, creates commit, and updates ref via REST API; outputs `branch_name` and `commit_sha`
-9. `Open PR to main via GitHub API` — creates PR targeting `main` with reviewers from `GH_USERNAME` secret
+1. `Validate version input` - rejects prerelease suffixes and non-`X.Y.Z` strings
+2. `actions/checkout@v4` - checks out `dev` branch (token: `GH_TOKEN_LIB`)
+3. `actions/setup-node@v4` - Node 20, GitHub Packages registry, `@tazama-lf` scope
+4. `Add @frmscoe registry scope` - appends registry line to `~/.npmrc`
+5. `Resolve internal rc dependencies to stable` - iterates `dependencies`, `devDependencies`, `peerDependencies`; resolves pinned-rc and range-with-rc patterns; fails if `dist-tags.latest` is still a prerelease
+6. `Update version in package.json` - writes the workflow input version
+7. `Regenerate package-lock.json` - runs `npm install --package-lock-only`
+8. `Commit and push to release branch via GitHub API` - creates/resets `release/v<N>` branch at current dev HEAD; builds tree, creates commit, and updates ref via REST API; outputs `branch_name` and `commit_sha`
+9. `Open PR to main via GitHub API` - creates PR targeting `main` with reviewers from `GH_USERNAME` secret
 
 ---
 
@@ -49,7 +49,7 @@ Prepares a library release PR from `dev` → `main`. Given a target stable versi
 
 | Secret | Scope | Purpose |
 |--------|-------|---------|
-| `GH_TOKEN_LIB` | org | API commits, npm install auth, PR creation — classic PAT requires `repo`, `workflow`, `read:packages` |
+| `GH_TOKEN_LIB` | org | API commits, npm install auth, PR creation - classic PAT requires `repo`, `workflow`, `read:packages` |
 
 ---
 
@@ -66,17 +66,17 @@ Prepares a library release PR from `dev` → `main`. Given a target stable versi
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|--------------|
-| `actions/checkout` | tag ref `v4` | — |
-| `actions/setup-node` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `actions/setup-node` | tag ref `v4` | - |
 
 ---
 
 ## Known Limitations / Notes
 
-- `checkov:skip=CKV_GHA_7` annotation suppresses a false-positive: the `version` input controls only the release branch name and `package.json` version — not the build artifact source.
+- `checkov:skip=CKV_GHA_7` annotation suppresses a false-positive: the `version` input controls only the release branch name and `package.json` version - not the build artifact source.
 - If `release/v<N>` already exists it is force-reset to the current `dev` HEAD, enabling idempotent reruns without manual cleanup.
 - The PR body does not include an auto-generated changelog; reviewers should compare `dev` to `main` manually before approving.
-- **`GH_TOKEN_LIB` required scopes (classic PAT):** `repo` (covers creating commits via the GitHub REST API, creating/resetting the `release/v<N>` branch, and opening the PR to main — equivalent to `contents: write` + `pull-requests: write` in fine-grained token terms), `workflow` (required when any commit touches `.github/workflows/` files), and `read:packages` (npm install from GitHub Packages). Commits created via the GitHub API with a token bearing the `repo` scope are automatically marked **Verified** by GitHub — no GPG signing key is needed on the runner.
+- **`GH_TOKEN_LIB` required scopes (classic PAT):** `repo` (covers creating commits via the GitHub REST API, creating/resetting the `release/v<N>` branch, and opening the PR to main - equivalent to `contents: write` + `pull-requests: write` in fine-grained token terms), `workflow` (required when any commit touches `.github/workflows/` files), and `read:packages` (npm install from GitHub Packages). Commits created via the GitHub API with a token bearing the `repo` scope are automatically marked **Verified** by GitHub - no GPG signing key is needed on the runner.
 
 ---
 

--- a/workflow-docs/release.md
+++ b/workflow-docs/release.md
@@ -31,16 +31,16 @@ Automates the GitHub release creation process. Triggered by a `repository_dispat
 
 **Steps:**
 
-1. `actions/checkout@v2` — checks out `main` with full tag history
-2. `Determine Release Type` — parses commit messages; maps `BREAKING CHANGE`/`feat!` → major, `feat:` → minor, all others → patch; uses `git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"` so repos with no tags default to `v0.0.0` rather than failing
-3. `Bump Version` — increments the appropriate version component; same `git describe` fallback applied here
-4. `Get Milestone Details` — validates `MILESTONE_NUMBER` from `client_payload` is non-empty (exits 1 with an error message if unset) then fetches milestone title and description via GitHub API
-5. `Generate Changelog` — compiles changelog from merged PRs since last tag
-6. `Display Changelog` — prints to runner log
-7. `Attach Changelog to Release` — writes changelog content
-8. `Create Release` — creates the GitHub release with the new tag
-9. `Update CHANGELOG.md File` — prepends the new changelog entry
-10. `Update VERSION File` — writes new version string
+1. `actions/checkout@v2` - checks out `main` with full tag history
+2. `Determine Release Type` - parses commit messages; maps `BREAKING CHANGE`/`feat!` → major, `feat:` → minor, all others → patch; uses `git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"` so repos with no tags default to `v0.0.0` rather than failing
+3. `Bump Version` - increments the appropriate version component; same `git describe` fallback applied here
+4. `Get Milestone Details` - validates `MILESTONE_NUMBER` from `client_payload` is non-empty (exits 1 with an error message if unset) then fetches milestone title and description via GitHub API
+5. `Generate Changelog` - compiles changelog from merged PRs since last tag
+6. `Display Changelog` - prints to runner log
+7. `Attach Changelog to Release` - writes changelog content
+8. `Create Release` - creates the GitHub release with the new tag
+9. `Update CHANGELOG.md File` - prepends the new changelog entry
+10. `Update VERSION File` - writes new version string
 ## Required Secrets
 
 None (uses auto-provided `GITHUB_TOKEN`).
@@ -59,7 +59,7 @@ None (uses auto-provided `GITHUB_TOKEN`).
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v2` | — |
+| `actions/checkout` | tag ref `v2` | - |
 
 ---
 
@@ -67,7 +67,7 @@ None (uses auto-provided `GITHUB_TOKEN`).
 
 - Uses deprecated `::set-output name=...` syntax; should be migrated to `$GITHUB_OUTPUT`.
 - Uses `actions/checkout@v2`; should be upgraded to `v4`.
-- No actions are pinned to commit SHAs — all use mutable tag refs, which is a supply-chain risk.
+- No actions are pinned to commit SHAs - all use mutable tag refs, which is a supply-chain risk.
 - `dependabot[bot]` actors are excluded.
 - `git describe` calls use `2>/dev/null || echo ""` (empty string) fallback. When no tag exists, `GIT_LOG_RANGE` resolves to `HEAD` (all commits) rather than the invalid ref `v0.0.0..HEAD`, which would cause `git log` to exit non-zero on a first release. The `Bump Version` step still uses a `v0.0.0` arithmetic base so the first release correctly becomes `v0.0.1`/`v0.1.0`/`v1.0.0`.
 - `MILESTONE_NUMBER` is validated non-empty before the GitHub API call; a missing or empty value exits 1 with a clear error rather than silently passing a malformed URL to `curl`.

--- a/workflow-docs/sbom.md
+++ b/workflow-docs/sbom.md
@@ -31,9 +31,9 @@ Generates a Software Bill of Materials (SBOM) for the Docker image using Anchore
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `docker build . --file Dockerfile --tag localbuild/testimage:latest` — builds the Docker image locally
-3. `anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a` — scans the image; outputs `image.spdx.json` artifact; submits dependency snapshot to GitHub via Dependency Submission API
+1. `actions/checkout@v4` - checks out source
+2. `docker build . --file Dockerfile --tag localbuild/testimage:latest` - builds the Docker image locally
+3. `anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a` - scans the image; outputs `image.spdx.json` artifact; submits dependency snapshot to GitHub via Dependency Submission API
 
 ---
 
@@ -55,15 +55,15 @@ None.
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|--------------|
-| `actions/checkout` | tag ref `v4` | — |
-| `anchore/sbom-action` | `bb716408e75840bbb01e839347cd213767269d4a` | — |
+| `actions/checkout` | tag ref `v4` | - |
+| `anchore/sbom-action` | `bb716408e75840bbb01e839347cd213767269d4a` | - |
 
 ---
 
 ## Known Limitations / Notes
 
 - `dependabot[bot]` actors are excluded.
-- Synced to all repos including library repos that have no `Dockerfile`; the `docker build` step will fail in those repos. Consider excluding library repos (`PUBLISH_REPOS`) from receiving this file — tracked in tazama-lf/workflows#35.
+- Synced to all repos including library repos that have no `Dockerfile`; the `docker build` step will fail in those repos. Consider excluding library repos (`PUBLISH_REPOS`) from receiving this file - tracked in tazama-lf/workflows#35.
 
 ---
 

--- a/workflow-docs/scorecard.md
+++ b/workflow-docs/scorecard.md
@@ -30,14 +30,14 @@ Runs the OSSF Scorecard supply-chain security analysis to assess repository secu
 
 ## Jobs
 
-### `analysis` — Scorecard analysis
+### `analysis` - Scorecard analysis
 
 **Steps:**
 
-1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` — checks out source (`persist-credentials: false`)
-2. `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a` — runs analysis; outputs `results.sarif`; `publish_results=true` only on `main`, `schedule`, or `branch_protection_rule` events
-3. `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` — uploads `results.sarif` artifact (5-day retention)
-4. `github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc` — uploads SARIF to code scanning dashboard
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` - checks out source (`persist-credentials: false`)
+2. `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a` - runs analysis; outputs `results.sarif`; `publish_results=true` only on `main`, `schedule`, or `branch_protection_rule` events
+3. `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` - uploads `results.sarif` artifact (5-day retention)
+4. `github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc` - uploads SARIF to code scanning dashboard
 
 ---
 
@@ -52,7 +52,7 @@ None (uses GitHub OIDC token via `id-token: write`).
 | Group | Behaviour |
 |-------|-----------|
 | Service repos (`REPOS` minus `PUBLISH_REPOS`) | Receives this file |
-| `PUBLISH_REPOS` | **Excluded** — scorecard is scoped to service repos only |
+| `PUBLISH_REPOS` | **Excluded** - scorecard is scoped to service repos only |
 
 ---
 

--- a/workflow-docs/sync-workflows.md
+++ b/workflow-docs/sync-workflows.md
@@ -34,7 +34,7 @@ Propagates canonical workflow files from this repository to all configured targe
 | `SPECIFIC_REPOS` | Library and non-Docker repos that skip `SPECIFIC_FILES` |
 | `SPECIFIC_FILES` | `dockerhub-image-build.yml dockerhub-image-build-rc.yml` |
 | `PUBLISH_REPOS` | Library repos that receive `publish.yml`, `version-check.yml`, `release-train.yml` but not `scorecard.yml` |
-| `RULE_REPOS` | `rule-901`, `rule-902` — receive caller stubs for `package-rule*.yml` instead of the full canonical |
+| `RULE_REPOS` | `rule-901`, `rule-902` - receive caller stubs for `package-rule*.yml` instead of the full canonical |
 
 **Org routing:** All repos in `REPOS` are cloned from the `tazama-lf` org.
 
@@ -46,10 +46,10 @@ Propagates canonical workflow files from this repository to all configured targe
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out this workflows repo
-2. `Set up Git` — configures git identity for commits
-3. `Get actor details` — captures the triggering actor's name and email for commit attribution; uses the PR author for `pull_request` events and `github.actor` for `push`/`workflow_dispatch` events
-4. `Sync Workflows to Other Repos` — main loop: clones each repo, ensures `dev` branch exists (creates from default branch if absent), deletes any existing `sync-workflows-update` branch, creates a fresh `sync-workflows-update` from `dev`, applies per-file sync rules, commits changes, pushes, opens PR. **`sync-workflows-update` is a reserved branch name** — do not use it for regular development contributions.
+1. `actions/checkout@v4` - checks out this workflows repo
+2. `Set up Git` - configures git identity for commits
+3. `Get actor details` - captures the triggering actor's name and email for commit attribution; uses the PR author for `pull_request` events and `github.actor` for `push`/`workflow_dispatch` events
+4. `Sync Workflows to Other Repos` - main loop: clones each repo, ensures `dev` branch exists (creates from default branch if absent), deletes any existing `sync-workflows-update` branch, creates a fresh `sync-workflows-update` from `dev`, applies per-file sync rules, commits changes, pushes, opens PR. **`sync-workflows-update` is a reserved branch name** - do not use it for regular development contributions.
 
 ---
 
@@ -74,7 +74,7 @@ Propagates canonical workflow files from this repository to all configured targe
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
 
 ---
 
@@ -89,4 +89,4 @@ Propagates canonical workflow files from this repository to all configured targe
 
 ## Repository Overrides
 
-Not applicable — this workflow is canonical-only and is never distributed.
+Not applicable - this workflow is canonical-only and is never distributed.

--- a/workflow-docs/version-check.md
+++ b/workflow-docs/version-check.md
@@ -31,8 +31,8 @@ Blocks a pull request from merging to `main` if `package.json` contains a prerel
 
 **Steps:**
 
-1. `actions/checkout@v4` — checks out source
-2. `Reject prerelease version on main PR` — reads `.version` from `package.json` via `jq`; exits `1` with an actionable message (showing both the current version and the corrected stable version) if a `-` suffix is detected
+1. `actions/checkout@v4` - checks out source
+2. `Reject prerelease version on main PR` - reads `.version` from `package.json` via `jq`; exits `1` with an actionable message (showing both the current version and the corrected stable version) if a `-` suffix is detected
 
 ---
 
@@ -47,7 +47,7 @@ None.
 | Group | Behaviour |
 |-------|-----------|
 | `PUBLISH_REPOS` | Receives this file |
-| All service repos (non-`PUBLISH_REPOS`) | **Excluded** — service repos do not publish npm packages and do not use the prerelease guard |
+| All service repos (non-`PUBLISH_REPOS`) | **Excluded** - service repos do not publish npm packages and do not use the prerelease guard |
 
 ---
 
@@ -55,7 +55,7 @@ None.
 
 | Action | Pinned SHA | Semver alias |
 |--------|-----------|--------------|
-| `actions/checkout` | tag ref `v4` | — |
+| `actions/checkout` | tag ref `v4` | - |
 
 ---
 


### PR DESCRIPTION
﻿## Summary

Extends sync coverage to five previously unsynced active `tazama-lf` repositories and introduces a new dual-image Docker workflow pair for repos with separate backend and frontend containers.

## Changes

### `sync-workflows.yml`
- Added `data-enrichment-service` and `event-monitoring-service` to `REPOS` - both have root-level Dockerfiles and follow the standard single-container service pattern
- Added `case-management-system`, `connection-studio`, `rule-studio` to both `REPOS` (receive all common workflows) and `SPECIFIC_REPOS` (suppress single-image Docker workflows)
- Added `dockerhub-image-build-dual.yml` and `dockerhub-image-build-dual-rc.yml` to `SPECIFIC_FILES` so they are not accidentally pushed to standard service repos via sync

### New workflows
- `dockerhub-image-build-dual.yml` - builds and pushes `tazamaorg/<repo>-backend:<version>` and `tazamaorg/<repo>-frontend:<version>` from `./backend` and `./frontend` subdirectory contexts; version read from each subdirectory's `package.json`; fires on `push: main` and `release: published`
- `dockerhub-image-build-dual-rc.yml` - RC variant; floating `:rc` tag; fires on `push: dev`

> These workflows are **not distributed via sync**. They must be committed directly to each dual-container repo (`case-management-system`, `connection-studio`, `rule-studio`) in a follow-up step.

### Docs
- `workflow-docs/dockerhub-image-build-dual.md` - new doc following the standard template
- `workflow-docs/dockerhub-image-build-dual-rc.md` - new doc following the standard template
- `README.md` - added dual-container repo class to Repository Classes table; added SDLC Section 3 for dual-container repos; added new workflow rows to Canonical Workflow Reference table; updated Sync Distribution table; updated target repo count 26 -> 31

## Repos affected by sync

When merged, `sync-workflows.yml` will open `sync-workflows-update` PRs in all 31 target repos. Net new repos receiving common workflows for the first time:

| Repo | Sync category | Workflows received |
|------|--------------|-------------------|
| `data-enrichment-service` | `REPOS` | Full set including Docker build workflows |
| `event-monitoring-service` | `REPOS` | Full set including Docker build workflows |
| `case-management-system` | `REPOS` + `SPECIFIC_REPOS` | Common workflows only (no Docker build workflows) |
| `connection-studio` | `REPOS` + `SPECIFIC_REPOS` | Common workflows only (no Docker build workflows) |
| `rule-studio` | `REPOS` + `SPECIFIC_REPOS` | Common workflows only (no Docker build workflows) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker image publishing pipelines for dual-container services (separate backend and frontend), including RC publishing on dev and versioned publishing on main/releases.

* **Documentation**
  * Documented dual-container service classification and added pages for the new publishing workflows.
  * Standardized punctuation/formatting across many workflow docs for consistency.

* **Chores**
  * Updated workflow sync rules to include additional repos and exclude the dual-container workflow files from sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->