### PR TITLE
fix: add missing echo step to dual-rc workflow (recon follow-up)

### DIFF
--- a/.github/workflows/dockerhub-image-build-dual-rc.yml
+++ b/.github/workflows/dockerhub-image-build-dual-rc.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
 
+      - name: Use the custom ENV variable
+        run: |
+          echo $REPO_NAME
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
@@ -102,6 +106,10 @@ jobs:
       - name: Set ENV variables
         run: |
           echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Use the custom ENV variable
+        run: |
+          echo $REPO_NAME
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
﻿## Summary

Recon between `dockerhub-image-build-rc.yml` and `dockerhub-image-build-dual-rc.yml` revealed that the `Use the custom ENV variable` echo debug step (present in both jobs of the single-image RC) was absent from both jobs of the dual variant.

## Change

Added the missing step to `push_backend_rc` and `push_frontend_rc`:

```yaml
- name: Use the custom ENV variable
  run: |
    echo $REPO_NAME
```

This step echoes `REPO_NAME` immediately after it is set, providing a visible confirmation in the Actions log. It is present in all other Docker publish workflows in this repo.