### PR TITLE
feat(ci): add library-dependency-rollout workflow and consumer catalog

### DIFF
--- a/.github/workflows/library-dependency-rollout.yml
+++ b/.github/workflows/library-dependency-rollout.yml
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Fires in a library repo when package.json is updated on dev (i.e. after a PR merges).
+# Reads the new rc version, looks up every registered consumer repo in library-consumers.json,
+# updates the exact version pin in each consumer's package.json, regenerates package-lock.json
+# via `npm install --package-lock-only`, commits both files to a shared dep/library-dependency-bump
+# branch, and creates or updates a single PR per consumer targeting dev.
+#
+# Multiple library bumps coalesce: if dep/library-dependency-bump already exists in a consumer
+# (from a prior library rollout), the new commit is pushed on top of the existing branch and the
+# open PR is reused rather than a duplicate being opened.
+#
+# Only runs for rc versions (e.g. 4.0.0-rc.3). Stable-version dependency resolution is handled
+# by release-train.yml in each consumer repo.
+#
+# RESERVED BRANCH NAME: dep/library-dependency-bump is managed by this workflow in every consumer
+# repo. Do not use this branch name for regular development contributions.
+#
+# Please do not attempt to edit this flow without the direct consent from the DevOps team.
+# This file is managed centrally.
+
+name: Library Dependency Rollout
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+
+concurrency:
+  group: library-dependency-rollout-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  rollout:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout library repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
+
+      - name: Read library package.json
+        id: lib_pkg
+        run: |
+          PKG_NAME=$(jq -r '.name' package.json)
+          PKG_VERSION=$(jq -r '.version' package.json)
+          if [ -z "$PKG_NAME" ] || [ "$PKG_NAME" = "null" ]; then
+            echo "::error::Could not read package name from package.json."
+            exit 1
+          fi
+          if [ -z "$PKG_VERSION" ] || [ "$PKG_VERSION" = "null" ]; then
+            echo "::error::Could not read version from package.json."
+            exit 1
+          fi
+          echo "name=${PKG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${PKG_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Library: ${PKG_NAME}@${PKG_VERSION}"
+
+      - name: Skip if not an rc version
+        id: check_rc
+        run: |
+          VERSION="${{ steps.lib_pkg.outputs.version }}"
+          if [[ "$VERSION" != *"-rc."* ]]; then
+            echo "Version '${VERSION}' is not an rc release. Rollout only runs for rc versions on dev. Exiting."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Git signing
+        if: steps.check_rc.outputs.skip != 'true'
+        run: |
+          git config --global user.name 'Justus-at-Tazama'
+          git config --global user.email '123470803+Justus-at-Tazama@users.noreply.github.com'
+          git config --global credential.helper store
+          if [ -z "${{ secrets.SSH_SIGNING_KEY }}" ]; then
+            echo "::error::SSH_SIGNING_KEY secret is not set. Commits cannot be signed."
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_SIGNING_KEY }}" | base64 -d > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          ssh-keygen -y -f ~/.ssh/signing_key > /dev/null || {
+            echo "::error::SSH_SIGNING_KEY is not a valid SSH private key or is passphrase-protected."
+            exit 1
+          }
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/signing_key
+          git config --global commit.gpgsign true
+
+      - name: Set up Node.js
+        if: steps.check_rc.outputs.skip != 'true'
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: '20'
+
+      - name: Fetch consumer catalog
+        if: steps.check_rc.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          HTTP_STATUS=$(curl -s -o /tmp/catalog-response.json -w "%{http_code}" \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/tazama-lf/workflows/contents/library-consumers.json?ref=dev")
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::Could not fetch library-consumers.json from tazama-lf/workflows (HTTP ${HTTP_STATUS})."
+            cat /tmp/catalog-response.json
+            exit 1
+          fi
+          jq -r '.content' /tmp/catalog-response.json | base64 -d > /tmp/library-consumers.json
+          echo "Consumer catalog loaded."
+          CONSUMER_COUNT=$(jq --arg pkg "${{ steps.lib_pkg.outputs.name }}" '.[$pkg].consumers | length // 0' /tmp/library-consumers.json)
+          echo "Consumers registered for ${{ steps.lib_pkg.outputs.name }}: ${CONSUMER_COUNT}"
+
+      - name: Roll out to consumers
+        if: steps.check_rc.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN_LIB: ${{ secrets.GH_TOKEN_LIB }}
+          PKG_NAME: ${{ steps.lib_pkg.outputs.name }}
+          PKG_VERSION: ${{ steps.lib_pkg.outputs.version }}
+          PR_REVIEWERS: ${{ secrets.GH_USERNAME }}
+        run: |
+          set -euo pipefail
+
+          BUMP_BRANCH="dep/library-dependency-bump"
+          SIGNED_OFF_BY="Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>"
+          WORK_DIR=$(mktemp -d)
+
+          # Read consumers for this library from the catalog
+          CONSUMERS=$(jq -r --arg pkg "$PKG_NAME" '.[$pkg].consumers // [] | .[] | "\(.org)/\(.repo)"' /tmp/library-consumers.json)
+
+          if [ -z "$CONSUMERS" ]; then
+            echo "No consumers registered for ${PKG_NAME} in library-consumers.json. Nothing to do."
+            echo "## Library Dependency Rollout: ${PKG_NAME}@${PKG_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No consumers registered. Update \`library-consumers.json\` in tazama-lf/workflows if this is unexpected." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Job summary header
+          echo "## Library Dependency Rollout: \`${PKG_NAME}@${PKG_VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Repo | Result | Details |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|---------|" >> "$GITHUB_STEP_SUMMARY"
+
+          for CONSUMER in $CONSUMERS; do
+            ORG="${CONSUMER%%/*}"
+            REPO="${CONSUMER##*/}"
+            REPO_DIR="${WORK_DIR}/${ORG}-${REPO}"
+
+            echo ""
+            echo "=== Processing ${ORG}/${REPO} ==="
+
+            # Clone consumer repo
+            if ! git clone \
+                --depth=50 \
+                "https://x-access-token:${GH_TOKEN}@github.com/${ORG}/${REPO}.git" \
+                "${REPO_DIR}" 2>&1; then
+              echo "::warning::Could not clone ${ORG}/${REPO}. Skipping."
+              echo "| \`${CONSUMER}\` | ❌ Clone failed | Could not clone repo |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            cd "${REPO_DIR}"
+
+            if ! git checkout dev 2>&1; then
+              echo "::warning::Could not checkout dev in ${ORG}/${REPO}. Skipping."
+              echo "| \`${CONSUMER}\` | ❌ No dev branch | Could not checkout dev |" >> "$GITHUB_STEP_SUMMARY"
+              cd "${WORK_DIR}"
+              continue
+            fi
+
+            # Check if this library is actually in package.json
+            if [ ! -f package.json ]; then
+              echo "${ORG}/${REPO} has no package.json on dev - skipping."
+              echo "| \`${CONSUMER}\` | ⏭️ Skipped | No package.json on dev |" >> "$GITHUB_STEP_SUMMARY"
+              cd "${WORK_DIR}"
+              continue
+            fi
+
+            if ! jq -e --arg pkg "$PKG_NAME" '(.dependencies // {}) + (.devDependencies // {}) | has($pkg)' package.json > /dev/null 2>&1; then
+              echo "${PKG_NAME} not found in ${ORG}/${REPO}/package.json - skipping."
+              echo "| \`${CONSUMER}\` | ⏭️ Skipped | \`${PKG_NAME}\` not in package.json |" >> "$GITHUB_STEP_SUMMARY"
+              cd "${WORK_DIR}"
+              continue
+            fi
+
+            # Determine if dep/library-dependency-bump already exists in the remote
+            BRANCH_EXISTS=false
+            if git ls-remote --heads origin "${BUMP_BRANCH}" | grep -q "${BUMP_BRANCH}"; then
+              BRANCH_EXISTS=true
+              # Fetch the branch so we have full history for the lockfile regeneration
+              git fetch origin "${BUMP_BRANCH}"
+              git checkout -b "${BUMP_BRANCH}" "origin/${BUMP_BRANCH}"
+              echo "Branch ${BUMP_BRANCH} already exists - appending bump commit."
+            else
+              git checkout -b "${BUMP_BRANCH}"
+              echo "Created new branch ${BUMP_BRANCH} from dev."
+            fi
+
+            # Update version pin in package.json using jq
+            UPDATED_PKG=$(jq --arg pkg "$PKG_NAME" --arg ver "$PKG_VERSION" \
+              'if .dependencies | has($pkg) then .dependencies[$pkg] = $ver else . end |
+               if .devDependencies | has($pkg) then .devDependencies[$pkg] = $ver else . end' \
+              package.json)
+            echo "$UPDATED_PKG" > package.json
+            echo "Updated ${PKG_NAME} to ${PKG_VERSION} in package.json"
+
+            # Configure .npmrc for GitHub Packages access (append to avoid overwriting repo's .npmrc)
+            echo "@tazama-lf:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+            echo "@frmscoe:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+            echo "//npm.pkg.github.com/:_authToken=${GH_TOKEN_LIB}" >> ~/.npmrc
+
+            # Regenerate package-lock.json with retries
+            NPM_OK=false
+            for attempt in 1 2 3; do
+              echo "npm install --package-lock-only (attempt ${attempt}/3)..."
+              if npm install --package-lock-only --ignore-scripts 2>&1; then
+                NPM_OK=true
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "Attempt ${attempt} failed. Waiting 30s before retry..."
+                sleep 30
+              fi
+            done
+
+            if [ "$NPM_OK" = "false" ]; then
+              echo "::warning::npm install --package-lock-only failed for ${ORG}/${REPO} after 3 attempts. Skipping."
+              echo "| \`${CONSUMER}\` | ⚠️ npm failed | package-lock.json could not be regenerated after 3 attempts |" >> "$GITHUB_STEP_SUMMARY"
+              cd "${WORK_DIR}"
+              continue
+            fi
+
+            # Stage changes
+            git add package.json package-lock.json
+
+            if git diff --cached --quiet; then
+              echo "No changes to commit for ${ORG}/${REPO} - already at ${PKG_VERSION}."
+              echo "| \`${CONSUMER}\` | ✅ Already up to date | No changes needed |" >> "$GITHUB_STEP_SUMMARY"
+              cd "${WORK_DIR}"
+              continue
+            fi
+
+            # Commit with SSH signing
+            git commit \
+              -m "chore(deps): bump ${PKG_NAME} to ${PKG_VERSION}" \
+              -m "${SIGNED_OFF_BY}"
+
+            # Push (force-with-lease to avoid overwriting concurrent pushes)
+            if ! git push \
+                "https://x-access-token:${GH_TOKEN}@github.com/${ORG}/${REPO}.git" \
+                "${BUMP_BRANCH}" \
+                --force-with-lease 2>&1; then
+              echo "::warning::Push failed for ${ORG}/${REPO}. Another rollout may have pushed concurrently. Re-run this workflow to retry."
+              echo "| \`${CONSUMER}\` | ❌ Push failed | Concurrent push conflict - re-run to retry |" >> "$GITHUB_STEP_SUMMARY"
+              cd "${WORK_DIR}"
+              continue
+            fi
+
+            # Check for existing open PR from dep/library-dependency-bump → dev
+            EXISTING_PR_URL=$(curl -sf \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${ORG}/${REPO}/pulls?state=open&head=${ORG}:${BUMP_BRANCH}&base=dev" \
+              | jq -r '.[0].html_url // ""')
+
+            if [ -n "$EXISTING_PR_URL" ]; then
+              echo "Existing PR updated: ${EXISTING_PR_URL}"
+              echo "| \`${CONSUMER}\` | ✅ PR updated | [View PR](${EXISTING_PR_URL}) |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              # Build PR body listing current bump plus any prior bumps already on the branch
+              # Collect all chore(deps): bump commits on this branch not on dev
+              PRIOR_BUMPS=$(git log "origin/dev..HEAD" --format="%s" 2>/dev/null \
+                | grep -E '^chore\(deps\): bump ' \
+                | grep -v "bump ${PKG_NAME}" \
+                || true)
+
+              PR_BODY_FILE=$(mktemp)
+              {
+                echo "## Library dependency bump"
+                echo ""
+                echo "This PR was automatically generated by \`library-dependency-rollout.yml\`."
+                echo ""
+                echo "### Updated packages"
+                echo ""
+                echo "| Package | Version |"
+                echo "|---------|---------|"
+                echo "| \`${PKG_NAME}\` | \`${PKG_VERSION}\` |"
+                if [ -n "$PRIOR_BUMPS" ]; then
+                  while IFS= read -r line; do
+                    # Extract "bump <pkg> to <ver>" from commit subject
+                    BUMP_PKG=$(echo "$line" | sed 's/chore(deps): bump \(.*\) to .*/\1/')
+                    BUMP_VER=$(echo "$line" | sed 's/chore(deps): bump .* to \(.*\)/\1/')
+                    echo "| \`${BUMP_PKG}\` | \`${BUMP_VER}\` |"
+                  done <<< "$PRIOR_BUMPS"
+                fi
+                echo ""
+                echo "> \`package-lock.json\` has been regenerated. Run \`npm install\` locally to sync your working copy after merging."
+                echo ""
+                echo "Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>"
+              } > "$PR_BODY_FILE"
+
+              # Create PR
+              PR_PAYLOAD_FILE=$(mktemp)
+              jq -n \
+                --arg title "chore(deps): bump library dependencies" \
+                --arg body "$(cat "$PR_BODY_FILE")" \
+                --arg head "${BUMP_BRANCH}" \
+                --arg base "dev" \
+                '{title: $title, body: $body, head: $head, base: $base}' \
+                > "$PR_PAYLOAD_FILE"
+
+              CREATE_RESPONSE=$(curl -sf \
+                -X POST \
+                -H "Authorization: token ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H "Content-Type: application/json" \
+                --data "@${PR_PAYLOAD_FILE}" \
+                "https://api.github.com/repos/${ORG}/${REPO}/pulls" || echo '{}')
+
+              PR_URL=$(echo "$CREATE_RESPONSE" | jq -r '.html_url // ""')
+              PR_NUMBER=$(echo "$CREATE_RESPONSE" | jq -r '.number // ""')
+
+              if [ -n "$PR_URL" ]; then
+                echo "PR created: ${PR_URL}"
+                echo "| \`${CONSUMER}\` | ✅ PR created | [#${PR_NUMBER}](${PR_URL}) |" >> "$GITHUB_STEP_SUMMARY"
+
+                # Request reviewers if GH_USERNAME is set
+                if [ -n "${PR_REVIEWERS:-}" ] && [ -n "$PR_NUMBER" ]; then
+                  REVIEWER_PAYLOAD=$(jq -n --arg r "$PR_REVIEWERS" '{reviewers: [$r]}')
+                  curl -sf \
+                    -X POST \
+                    -H "Authorization: token ${GH_TOKEN}" \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    -H "Content-Type: application/json" \
+                    -d "$REVIEWER_PAYLOAD" \
+                    "https://api.github.com/repos/${ORG}/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+                    > /dev/null || echo "::warning::Could not request reviewer for ${ORG}/${REPO} PR #${PR_NUMBER}."
+                fi
+              else
+                PR_ERROR=$(echo "$CREATE_RESPONSE" | jq -r '.message // "unknown error"')
+                echo "::warning::PR creation failed for ${ORG}/${REPO}: ${PR_ERROR}"
+                echo "| \`${CONSUMER}\` | ⚠️ PR creation failed | ${PR_ERROR} |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+
+              rm -f "$PR_BODY_FILE" "$PR_PAYLOAD_FILE"
+            fi
+
+            cd "${WORK_DIR}"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "_Rollout triggered from \`${{ github.repository }}\` @ \`${{ github.sha }}\`_" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -196,8 +196,8 @@ jobs:
               if in_list "$repo" "$SPECIFIC_REPOS" && [[ " ${SPECIFIC_FILES} " =~ " ${filename} " ]]; then
                 continue
               fi
-              # publish.yml, version-check.yml, and release-train.yml: only copy to designated library repos
-              if [[ "${filename}" == "publish.yml" || "${filename}" == "version-check.yml" || "${filename}" == "release-train.yml" ]] && ! in_list "$repo" "$PUBLISH_REPOS"; then
+              # publish.yml, version-check.yml, release-train.yml, and library-dependency-rollout.yml: only copy to designated library repos
+              if [[ "${filename}" == "publish.yml" || "${filename}" == "version-check.yml" || "${filename}" == "release-train.yml" || "${filename}" == "library-dependency-rollout.yml" ]] && ! in_list "$repo" "$PUBLISH_REPOS"; then
                 continue
               fi
               # package-rule*.yml canonical definitions: never copy to rule repos - stubs are stamped below

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ When a new repository is created in the Tazama ecosystem, it needs to be enrolle
 
 ### Step 1 - Determine the repository class
 
-| Class | Receives Docker build workflows? | Receives `publish.yml` / `release-train.yml` / `library-dependency-rollout.yml`? |
-|-------|----------------------------------|-----------------------------------------------------------------------------------|
+| Class | Receives Docker build workflows? | Receives `publish.yml` / `version-check.yml` / `release-train.yml` / `library-dependency-rollout.yml`? |
+|-------|----------------------------------|----------------------------------------------------------------------------------------------------------|
 | Service repo (Docker-building) | ✅ Yes | ❌ No |
 | Dual-container service repo | ❌ No (add to `SPECIFIC_REPOS`) | ❌ No |
 | Multi-image service repo (biar) | ❌ No (add to `SPECIFIC_REPOS`) | ❌ No |
@@ -312,8 +312,9 @@ Add a documentation file for any new canonical workflow using [`workflow-docs/do
 
 > You only ever update this file in `tazama-lf/workflows`. You do not need to touch any library repo. The next time any library merges to `dev`, the rollout will automatically include the new consumer.
 
-1. Optionally re-run `audit-library-consumers.js` (in `C:\DevTools\GitHub\`) to regenerate the file from live data:
-   ```
+1. Optionally re-run your local copy of `audit-library-consumers.js` to regenerate the file from live data:
+
+   ```bash
    node audit-library-consumers.js --token <gh-pat>
    ```
 2. Review the output in `library-consumers.json`.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Library repos publish versioned npm packages under the `@tazama-lf` scope. They 
 4. **AUTO** - [standard PR check suite](#standard-pr-check-suite) fires.
 5. **Reviewer - MANUAL** - reviews, approves, merges PR to `dev`.
 6. **AUTO** - `publish.yml` fires on `push: dev`; detects the `-rc` suffix; publishes the package to GitHub Packages under the `rc` dist-tag.
+7. **AUTO** - `library-dependency-rollout.yml` fires on `push: dev` (path: `package.json`); updates the exact version pin in every registered consumer repo's `package.json`, regenerates `package-lock.json`, commits to `dep/library-dependency-bump`, and opens (or updates) a `dep/library-dependency-bump → dev` PR in each consumer. If a PR already exists from a prior library bump it is reused - multiple library updates coalesce into a single open PR per consumer.
 
 #### Release → main
 
@@ -213,6 +214,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `node.js.yml` | Node 20 CI: build, lint, test | `push: [dev,main]`, `pull_request: [dev,main]` | **Not synced** - each repo maintains its own copy |
 | `package-rule-rc.yml` | Reusable: build and push `:rc` Docker image for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `package-rule.yml` | Reusable: build and push `:latest`/`:X.Y.Z` Docker images for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
+| `library-dependency-rollout.yml` | On rc version merge to `dev` in a library repo, update the exact version pin in every registered consumer's `package.json`, regenerate `package-lock.json`, and open (or update) a `dep/library-dependency-bump → dev` PR | `push: [dev]` (path: `package.json`), `workflow_dispatch` | `PUBLISH_REPOS` only |
 | `publish.yml` | Publish npm package to GitHub Packages | `push: [main]`, `workflow_dispatch` | `PUBLISH_REPOS` only |
 | `release-train.yml` | Resolve rc deps, prepare release PR, bump version | `workflow_dispatch` | `PUBLISH_REPOS` only |
 | `release.yml` | Create GitHub release with auto-generated changelog as release body | `repository_dispatch: [release]` (from `milestone.yml`) | All repos |
@@ -231,7 +233,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 |-------|---------|-----------|
 | `REPOS` | All 32 tazama-lf target repos | Receive all workflows except those explicitly excluded |
 | `SPECIFIC_REPOS` | All library repos + `relay-service`, `batch-ppa`, `rule-executer`, `Full-Stack-Docker-Tazama` + dual-container repos (`case-management-system`, `connection-studio`, `rule-studio`) + multi-image repos (`biar`) | Skip `dockerhub-image-build.yml`, `dockerhub-image-build-rc.yml`, `dockerhub-image-build-dual.yml`, `dockerhub-image-build-dual-rc.yml` |
-| `PUBLISH_REPOS` | All library repos + `rule-901`, `rule-902` | Additionally receive `publish.yml`, `version-check.yml`, `release-train.yml`; skip `scorecard.yml` |
+| `PUBLISH_REPOS` | All library repos + `rule-901`, `rule-902` | Additionally receive `publish.yml`, `version-check.yml`, `release-train.yml`, `library-dependency-rollout.yml`; skip `scorecard.yml` |
 | `RULE_REPOS` | `rule-901`, `rule-902` | Receive caller stubs for `package-rule*.yml` instead of the full reusable workflow definition |
 
 **Always excluded from the sync bundle:**
@@ -247,6 +249,8 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 
 > ⚠️ **`sync-workflows-update` is a reserved branch name.** This branch is created and managed by `sync-workflows.yml` in every target repo. Do not use this name for regular development contributions - the sync workflow will delete it and recreate it fresh from `dev` on every run. If you have an open `sync-workflows-update` branch in a target repo, be aware it will be force-replaced the next time the workflow runs.
 
+> ⚠️ **`dep/library-dependency-bump` is a reserved branch name.** This branch is created and managed by `library-dependency-rollout.yml` in every consumer repo. Do not use this name for regular development contributions. Multiple library bumps coalesce onto this branch - the workflow pushes new commits onto an existing branch rather than creating a new one.
+
 ---
 
 ## Adding Automation to a New Repository
@@ -255,13 +259,13 @@ When a new repository is created in the Tazama ecosystem, it needs to be enrolle
 
 ### Step 1 - Determine the repository class
 
-| Class | Receives Docker build workflows? | Receives `publish.yml` / `release-train.yml`? |
-|-------|----------------------------------|-----------------------------------------------|
+| Class | Receives Docker build workflows? | Receives `publish.yml` / `release-train.yml` / `library-dependency-rollout.yml`? |
+|-------|----------------------------------|-----------------------------------------------------------------------------------|
 | Service repo (Docker-building) | ✅ Yes | ❌ No |
 | Dual-container service repo | ❌ No (add to `SPECIFIC_REPOS`) | ❌ No |
 | Multi-image service repo (biar) | ❌ No (add to `SPECIFIC_REPOS`) | ❌ No |
 | Other service repo (no Docker build) | ❌ No (add to `SPECIFIC_REPOS`) | ❌ No |
-| Library repo | ❌ No (add to `SPECIFIC_REPOS`) | ✅ Yes (add to `PUBLISH_REPOS`) |
+| Library repo | ❌ No (add to `SPECIFIC_REPOS`) | ✅ Yes (add to `PUBLISH_REPOS`); also add entry to `library-consumers.json` if it will be consumed by other repos |
 | Rule repo - tazama-lf | ❌ No (add to `SPECIFIC_REPOS` + `RULE_REPOS`) | ✅ Yes (add to `PUBLISH_REPOS`) |
 | Rule repo - frmscoe | n/a - managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows) | n/a |
 
@@ -299,6 +303,25 @@ Add a documentation file for any new canonical workflow using [`workflow-docs/do
 ---
 
 ## Routine Maintenance
+
+### Updating the library consumer catalog (`library-consumers.json`)
+
+`library-consumers.json` at the root of this repo is the canonical list of which repos consume which `@tazama-lf/*` library packages. It drives `library-dependency-rollout.yml`. The catalog is fetched at runtime by the rollout workflow from `tazama-lf/workflows@dev` - no library repo stores or owns the consumer list.
+
+**When to update:** when a new consumer repo is created, when a repo stops consuming a library, or when a new library is added.
+
+> You only ever update this file in `tazama-lf/workflows`. You do not need to touch any library repo. The next time any library merges to `dev`, the rollout will automatically include the new consumer.
+
+1. Optionally re-run `audit-library-consumers.js` (in `C:\DevTools\GitHub\`) to regenerate the file from live data:
+   ```
+   node audit-library-consumers.js --token <gh-pat>
+   ```
+2. Review the output in `library-consumers.json`.
+3. Open a PR to `dev` in this repo with the updated file.
+
+Alternatively, edit `library-consumers.json` directly and open a PR.
+
+---
 
 ### Pinned action SHA updates
 

--- a/library-consumers.json
+++ b/library-consumers.json
@@ -1,0 +1,319 @@
+{
+  "@tazama-lf/frms-coe-lib": {
+    "source-repo": "frms-coe-lib",
+    "consumers": [
+      {
+        "org": "tazama-lf",
+        "repo": "admin-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "auth-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "batch-ppa"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "data-enrichment-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "event-director"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "event-monitoring-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "event-sidecar"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "lumberjack"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "nats-utilities"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "relay-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "rule-901"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "rule-902"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "rule-executer"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "rule-studio-example"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "tms-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "transaction-aggregation-decisioning-processor"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "typology-processor"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-001"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-002"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-003"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-004"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-006"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-007"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-008"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-010"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-011"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-016"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-017"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-018"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-020"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-021"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-024"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-025"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-026"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-027"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-028"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-030"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-044"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-045"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-048"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-054"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-063"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-074"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-075"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-076"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-078"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-083"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-084"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-090"
+      },
+      {
+        "org": "frmscoe",
+        "repo": "rule-091"
+      }
+    ]
+  },
+  "@tazama-lf/frms-coe-startup-lib": {
+    "source-repo": "frms-coe-startup-lib",
+    "consumers": [
+      {
+        "org": "tazama-lf",
+        "repo": "admin-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "auth-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "data-enrichment-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "event-director"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "event-monitoring-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "relay-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "rule-executer"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "tms-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "transaction-aggregation-decisioning-processor"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "typology-processor"
+      }
+    ]
+  },
+  "@tazama-lf/auth-lib": {
+    "source-repo": "auth-lib",
+    "consumers": [
+      {
+        "org": "tazama-lf",
+        "repo": "admin-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "auth-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "data-enrichment-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "event-monitoring-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "tms-service"
+      }
+    ]
+  },
+  "@tazama-lf/auth-lib-provider-keycloak": {
+    "source-repo": "auth-lib-provider-keycloak",
+    "consumers": [
+      {
+        "org": "tazama-lf",
+        "repo": "auth-service"
+      }
+    ]
+  },
+  "@tazama-lf/tcs-lib": {
+    "source-repo": "tcs-lib",
+    "consumers": [
+      {
+        "org": "tazama-lf",
+        "repo": "admin-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "data-enrichment-service"
+      }
+    ]
+  },
+  "@tazama-lf/audit-lib": {
+    "source-repo": "audit-lib",
+    "consumers": []
+  },
+  "@tazama-lf/nats-relay-plugin": {
+    "source-repo": "relay-service-integration-nats",
+    "consumers": []
+  },
+  "@tazama-lf/rest-relay-plugin": {
+    "source-repo": "relay-service-integration-rest",
+    "consumers": []
+  },
+  "@tazama-lf/kafka-relay-plugin": {
+    "source-repo": "relay-service-integration-kafka",
+    "consumers": []
+  },
+  "@tazama-lf/rabbitmq-relay-plugin": {
+    "source-repo": "relay-service-integration-rabbitmq",
+    "consumers": []
+  }
+}

--- a/workflow-docs/library-dependency-rollout.md
+++ b/workflow-docs/library-dependency-rollout.md
@@ -47,7 +47,7 @@ Only runs for rc versions (e.g. `4.0.0-rc.3`). Stable-version dependency resolut
    - Clones the consumer repo (`--depth=50`)
    - Checks out `dev`; verifies `package.json` exists and contains the library as a dependency
    - Creates or checks out the `dep/library-dependency-bump` branch
-   - Updates the exact version pin in `dependencies` or `devDependencies` via an inline Node.js script (preserves `package.json` formatting)
+   - Updates the exact version pin in `dependencies` or `devDependencies` using `jq` (rewrites the file; formatting and key ordering may change)
    - Configures `~/.npmrc` for `@tazama-lf` and `@frmscoe` GitHub Packages scopes
    - Runs `npm install --package-lock-only --ignore-scripts` (3 attempts, 30 s delay between retries)
    - Commits `package.json` + `package-lock.json` with SSH signing and a DCO `Signed-off-by` trailer
@@ -100,7 +100,7 @@ When multiple libraries are bumped in quick succession:
 
 1. `frms-coe-lib` merges → rollout creates `dep/library-dependency-bump` in each consumer and opens a PR.
 2. `frms-coe-startup-lib` merges → rollout detects the existing branch and open PR, pushes an additional commit, and logs the PR URL. No duplicate PR is created.
-3. The consumer's PR now contains bumps for both libraries; the PR body lists all packages updated on the branch.
+3. The `dep/library-dependency-bump` branch now contains commits for both bumps; the existing PR is reused but its body is not updated.
 
 **Race condition:** If two library rollouts push to the same consumer branch concurrently, the second push may fail with `--force-with-lease`. In that case, re-run the workflow for the failing library to retry.
 
@@ -121,5 +121,5 @@ When multiple libraries are bumped in quick succession:
 
 | Group | Behaviour |
 |-------|-----------|
-| `PUBLISH_REPOS` | Receives this file (library repos only) |
+| `PUBLISH_REPOS` | Receives this file (publish-capable repos: library repos + `rule-901`, `rule-902`) |
 | All other groups | Does not receive this file |

--- a/workflow-docs/library-dependency-rollout.md
+++ b/workflow-docs/library-dependency-rollout.md
@@ -1,0 +1,125 @@
+# `library-dependency-rollout.yml`
+
+## Purpose
+
+Fires in a library repo when `package.json` is updated on `dev` (i.e. after a PR merges). Reads the new rc version, looks up every registered consumer repo in `library-consumers.json`, updates the exact version pin in each consumer's `package.json`, regenerates `package-lock.json` via `npm install --package-lock-only`, commits both files to a shared `dep/library-dependency-bump` branch in each consumer, and creates or updates a single PR per consumer targeting `dev`.
+
+Multiple library bumps coalesce: if `dep/library-dependency-bump` already exists in a consumer from a prior library rollout, the new commit is pushed on top of the existing branch and the open PR is reused rather than a duplicate being opened.
+
+Only runs for rc versions (e.g. `4.0.0-rc.3`). Stable-version dependency resolution is handled by `release-train.yml` in each consumer repo.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branch: `dev`, path: `package.json` |
+| `workflow_dispatch` | manual re-run |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Typical duration | ~2–5 min (scales with number of consumers) |
+| Concurrency | `library-dependency-rollout-<repository>`, `cancel-in-progress: false` |
+| Permissions | `contents: read` (all cross-repo operations use `GH_TOKEN`) |
+
+---
+
+## Jobs
+
+### `rollout`
+
+**Steps:**
+
+1. `actions/checkout@v6.0.2` - checks out `dev` in the library repo
+2. `Read library package.json` - extracts `name` and `version` from the library's own `package.json`
+3. `Skip if not an rc version` - exits gracefully if the version does not contain `-rc.` (stable merges are handled by `release-train.yml`)
+4. `Set up Git signing` - configures SSH commit signing using `SSH_SIGNING_KEY`, same pattern as `sync-workflows.yml`
+5. `actions/setup-node@v6.3.0` - installs Node 20
+6. `Fetch consumer catalog` - downloads `library-consumers.json` from `tazama-lf/workflows@dev` via the GitHub Contents API
+7. `Roll out to consumers` - for each consumer in the catalog:
+   - Clones the consumer repo (`--depth=50`)
+   - Checks out `dev`; verifies `package.json` exists and contains the library as a dependency
+   - Creates or checks out the `dep/library-dependency-bump` branch
+   - Updates the exact version pin in `dependencies` or `devDependencies` via an inline Node.js script (preserves `package.json` formatting)
+   - Configures `~/.npmrc` for `@tazama-lf` and `@frmscoe` GitHub Packages scopes
+   - Runs `npm install --package-lock-only --ignore-scripts` (3 attempts, 30 s delay between retries)
+   - Commits `package.json` + `package-lock.json` with SSH signing and a DCO `Signed-off-by` trailer
+   - Pushes with `--force-with-lease` to `dep/library-dependency-bump`
+   - If an open PR already exists from `dep/library-dependency-bump → dev`, logs the PR URL (new commit is already in it)
+   - Otherwise creates a new PR with title `chore(deps): bump library dependencies`, a body table listing all bumped packages on the branch, and requests a reviewer via `GH_USERNAME`
+8. Writes a job summary table showing each consumer: bumped, skipped, or failed
+
+**Per-consumer skip conditions:**
+- Could not clone repo
+- No `dev` branch
+- No `package.json` on `dev`
+- Library not listed in `dependencies` or `devDependencies`
+- `npm install --package-lock-only` failed after 3 retries (warning, not failure)
+- Push rejected due to concurrent rollout (warning - re-run the workflow)
+
+Consumer failures are warnings only and do not fail the overall job.
+
+---
+
+## Consumer Catalog (`library-consumers.json`)
+
+Located at the root of `tazama-lf/workflows`. Fetched at runtime by the rollout workflow via the GitHub Contents API - no library repo stores or owns the consumer list. Structure:
+
+```json
+{
+  "@tazama-lf/frms-coe-lib": {
+    "source-repo": "frms-coe-lib",
+    "consumers": [
+      { "org": "tazama-lf", "repo": "auth-service" },
+      { "org": "frmscoe", "repo": "rule-001" }
+    ]
+  }
+}
+```
+
+The catalog is bootstrapped by `audit-library-consumers.js` (in `C:\DevTools\GitHub\`) and maintained manually thereafter. When a new consumer repo is added to the ecosystem, add its entry to `library-consumers.json` and open a PR to `dev` in `tazama-lf/workflows`. You do not need to touch any library repo - the next time any library merges to `dev`, the rollout will automatically include the new consumer.
+
+---
+
+## Reserved Branch Name
+
+`dep/library-dependency-bump` is a reserved branch name in all consumer repos, managed exclusively by this workflow. Do not use this name for regular development contributions - the rollout will push over it.
+
+---
+
+## Multi-Library Coalescence
+
+When multiple libraries are bumped in quick succession:
+
+1. `frms-coe-lib` merges → rollout creates `dep/library-dependency-bump` in each consumer and opens a PR.
+2. `frms-coe-startup-lib` merges → rollout detects the existing branch and open PR, pushes an additional commit, and logs the PR URL. No duplicate PR is created.
+3. The consumer's PR now contains bumps for both libraries; the PR body lists all packages updated on the branch.
+
+**Race condition:** If two library rollouts push to the same consumer branch concurrently, the second push may fail with `--force-with-lease`. In that case, re-run the workflow for the failing library to retry.
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `SSH_SIGNING_KEY` | repo | Base64-encoded Ed25519 private key for signing commits (same key as `sync-workflows.yml`) |
+| `GH_TOKEN` | org | Clone, push, and create PRs in consumer repos across both `tazama-lf` and `frmscoe` orgs; fetch `library-consumers.json` |
+| `GH_TOKEN_LIB` | org | Read from GitHub Packages during `npm install --package-lock-only` |
+| `GH_USERNAME` | org | GitHub username to request as PR reviewer |
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| `PUBLISH_REPOS` | Receives this file (library repos only) |
+| All other groups | Does not receive this file |


### PR DESCRIPTION
## Summary

Adds an automated library dependency rollout system. When a library repo (e.g. `frms-coe-lib`) merges an rc version to `dev`, `library-dependency-rollout.yml` automatically opens version-bump PRs in every consuming repository.

## What changed

### New: `.github/workflows/library-dependency-rollout.yml`

- Triggers on `push: dev` (path: `package.json`) in library repos, plus `workflow_dispatch`
- Reads its own rc version from `package.json`; skips if not an rc version
- Fetches `library-consumers.json` from `tazama-lf/workflows@dev` at runtime
- For each consumer: clones the repo, updates the exact version pin via `jq`, regenerates `package-lock.json` via `npm install --package-lock-only --ignore-scripts`
- Commits with SSH signing + DCO trailer, pushes to `dep/library-dependency-bump` (force-with-lease)
- Checks for an existing open PR; creates one if absent; coalesces multiple library bumps onto the same branch and PR
- Consumer failures are warnings - they never fail the whole job
- Posts a job summary table showing bumped / skipped / failed per consumer
- Synced to `PUBLISH_REPOS` only (library repos + rule-901, rule-902)

### New: `library-consumers.json`

Static consumer catalog mapping each `@tazama-lf/*` package to its consuming repos. Fetched at runtime by the rollout workflow - no library repo needs to know about its consumers. Contains 68 consumer relationships across 74 repos, including:
- `@tazama-lf/frms-coe-lib` -> 50 consumers (17 tazama-lf + 33 frmscoe)
- `@tazama-lf/frms-coe-startup-lib` -> 10 consumers
- `@tazama-lf/auth-lib` -> 5 consumers
- Others: tcs-lib, auth-lib-provider-keycloak

### New: `workflow-docs/library-dependency-rollout.md`

Docs entry following the standard template: trigger table, execution context, full step list, consumer catalog section, reserved branch note, multi-library coalescence explanation, required secrets table, sync distribution table.

### Modified: `.github/workflows/sync-workflows.yml`

- Added `library-dependency-rollout.yml` to the `PUBLISH_REPOS`-only gate so it is not distributed to service repos

### Modified: `README.md`

- Added `library-dependency-rollout.yml` to the Canonical Workflow Reference table
- Updated the Sync Distribution table (PUBLISH_REPOS row)
- Added step 7 to the Library repos SDLC (Feature development -> dev)
- Added reserved branch warning for `dep/library-dependency-bump`
- Updated the Adding a New Repository table header and Library repo row
- Added new "Updating the library consumer catalog" Routine Maintenance section

## Reserved branch

`dep/library-dependency-bump` is managed exclusively by this workflow in consumer repos. Multiple library bumps coalesce onto this branch - the workflow pushes onto an existing branch rather than creating a new one.

## Required secrets (library repos)

| Secret | Purpose |
|--------|---------|
| `SSH_SIGNING_KEY` | Base64-encoded ed25519 key for signing commits |
| `GH_TOKEN` | PAT for cross-org clone, push, and PR creation |
| `GH_TOKEN_LIB` | PAT with `read:packages` scope for GitHub Packages npm auth |
| `GH_USERNAME` | GitHub username to assign as PR reviewer |

## Testing

The workflow can be triggered manually via `workflow_dispatch` on any library repo with a valid rc version in `package.json`. The consumer catalog can be refreshed by running `node audit-library-consumers.js --token <gh-pat>` and committing the updated `library-consumers.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated library dependency rollout workflow that propagates RC version updates across consumer repositories and manages pull request creation and updates.

* **Documentation**
  * Updated documentation with library dependency rollout process and requirements.
  * Added library consumer registry defining library-to-consumer relationships.

* **Chores**
  * Updated workflow sync distribution to include the new rollout workflow for publish-only repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->