### PR TITLE
feat(ci): add encoding-check workflow to block non-UTF-8 files on PR

### DIFF
--- a/.github/workflows/encoding-check.yml
+++ b/.github/workflows/encoding-check.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   encoding-check:
+    permissions:
+      contents: read
     if: |
       github.actor != 'dependabot[bot]' &&
       github.actor != 'dependabot-preview[bot]' &&

--- a/.github/workflows/encoding-check.yml
+++ b/.github/workflows/encoding-check.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This GitHub Actions workflow checks that all files changed in a pull request are encoded as UTF-8 without BOM.
+# It fails the check if any file starts with a UTF-16 LE (FF FE), UTF-16 BE (FE FF), or UTF-8 BOM (EF BB BF) marker.
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Encoding Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  encoding-check:
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'dependabot-preview[bot]' &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed to resolve both base and head SHAs
+
+      - name: Check file encodings
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Get the list of files added or modified in this PR (excludes deleted files)
+          mapfile -t changed_files < <(git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA")
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "No files changed in this PR."
+            exit 0
+          fi
+
+          violations=0
+
+          for f in "${changed_files[@]}"; do
+            # Read the first 3 bytes as a lowercase hex string (6 hex chars)
+            bom=$(head -c 3 "$f" | xxd -p | tr -d '\n' | cut -c1-6)
+
+            case "$bom" in
+              fffe* | feff*)
+                echo "::error file=${f}::Non-UTF-8 encoding detected: UTF-16 (BOM: ${bom}). Re-save the file as UTF-8 without BOM."
+                violations=$((violations + 1))
+                ;;
+              efbbbf)
+                echo "::error file=${f}::UTF-8 BOM detected (EF BB BF). Re-save the file as UTF-8 without BOM."
+                violations=$((violations + 1))
+                ;;
+            esac
+          done
+
+          if [ "$violations" -gt 0 ]; then
+            echo ""
+            echo "Found ${violations} file(s) with non-UTF-8-no-BOM encoding."
+            echo "To fix: open each flagged file in your editor and re-save as 'UTF-8' (not 'UTF-8 with BOM', not 'UTF-16')."
+            echo "In VS Code: click the encoding indicator in the status bar → 'Save with Encoding' → 'UTF-8'."
+            exit 1
+          fi
+
+          echo "All ${#changed_files[@]} changed file(s) passed the encoding check."
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `codeql.yml` | GitHub CodeQL SAST | `push: [dev,main]`, `pull_request: [dev,main]`, schedule | All repos |
 | `conventional-commits.yml` | Validate Conventional Commits spec | `pull_request` | All repos |
 | `dco-check.yml` | Verify DCO Signed-off-by on commits | `pull_request` | All repos |
+| `encoding-check.yml` | Fail a PR if any changed file is UTF-16 or UTF-8 BOM encoded | `pull_request` | All repos |
 | `dependency-review.yml` | Flag CVEs and licence issues in new deps | `pull_request` | All repos |
 | `dockerfile-linter.yml` | Hadolint lint of Dockerfiles | `pull_request` | All repos (no-op where no `Dockerfile` exists) |
 | `dockerhub-image-build-dual-rc.yml` | Build and push `:rc` Docker images for backend and frontend | `push: [dev]`, `workflow_dispatch` | **Not synced** - committed directly to dual-container repos only |

--- a/workflow-docs/encoding-check.md
+++ b/workflow-docs/encoding-check.md
@@ -1,0 +1,77 @@
+# `encoding-check.yml`
+
+## Purpose
+
+Checks every file added or modified in a pull request for non-UTF-8-no-BOM encodings. Fails the PR check and emits inline file annotations if any file starts with a UTF-16 LE (`FF FE`), UTF-16 BE (`FE FF`), or UTF-8 BOM (`EF BB BF`) marker. Preventative only - does not re-encode files automatically.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `pull_request` | types: `opened`, `synchronize`, `reopened` |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | < 30 s |
+| Concurrency | none (default GitHub behaviour) |
+| Permissions | `contents: read` (default) |
+
+---
+
+## Jobs
+
+### `encoding-check`
+
+**Steps:**
+
+1. `actions/checkout@v6.0.2` - checks out the repository with `fetch-depth: 0` so both the base and head SHAs are resolvable
+2. `Check file encodings` - for each file added or modified in the PR (deleted files excluded via `--diff-filter=d`):
+   - Reads the first 3 bytes using `head -c 3 | xxd -p`
+   - Compares the hex prefix against `fffe` (UTF-16 LE), `feff` (UTF-16 BE), and `efbbbf` (UTF-8 BOM)
+   - Emits a `::error file=<path>::` annotation for each violation so GitHub displays it inline on the PR
+   - Counts all violations and fails the job if any are found, with a remediation message pointing to VS Code's encoding selector
+
+Note: binary detection is not used as a pre-filter. UTF-16 files contain NUL bytes and are classified as binary by git, which would suppress the check. Instead, the BOM pattern itself is the discriminator - genuine binary files (images, compiled outputs, etc.) do not start with any of the three BOM sequences and pass cleanly.
+
+**Skip conditions:**
+- PR has no changed files
+- Actor is `dependabot[bot]`, `dependabot-preview[bot]`, or `github-actions[bot]`
+
+---
+
+## BOMs Detected
+
+| BOM bytes | Encoding | Error message |
+|-----------|----------|---------------|
+| `FF FE` | UTF-16 LE | `Non-UTF-8 encoding detected: UTF-16 (BOM: fffe). Re-save the file as UTF-8 without BOM.` |
+| `FE FF` | UTF-16 BE | `Non-UTF-8 encoding detected: UTF-16 (BOM: feff). Re-save the file as UTF-8 without BOM.` |
+| `EF BB BF` | UTF-8 BOM | `UTF-8 BOM detected (EF BB BF). Re-save the file as UTF-8 without BOM.` |
+
+---
+
+## Remediation
+
+In VS Code: click the encoding indicator in the status bar (bottom-right, shows e.g. `UTF-16 LE`) → **Save with Encoding** → **UTF-8**.
+
+In other editors, use the "Save As" / encoding option and select **UTF-8** (not "UTF-8 with BOM").
+
+---
+
+## Required Secrets
+
+None. Uses the default `GITHUB_TOKEN` (implicit) - no explicit secret needed.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|-----------|
+| All repos (`REPOS`) | Receives this file |


### PR DESCRIPTION
## Summary

Adds `encoding-check.yml` - a new PR check workflow that detects files with non-UTF-8-no-BOM encodings and blocks merge.

Resolves #87.

## What this does

For every file added or modified in a PR the workflow reads the first 3 bytes and checks for:

| BOM bytes | Encoding |
|-----------|----------|
| `FF FE` | UTF-16 LE |
| `FE FF` | UTF-16 BE |
| `EF BB BF` | UTF-8 BOM |

Each violation emits a `::error file=<path>::` annotation so GitHub displays it inline on the diff. The job fails if any violations are found, with a remediation message pointing to VS Code's encoding selector.

Binary pre-filtering is intentionally absent: git classifies UTF-16 files as binary (NUL bytes), so using `--diff-filter` or `git diff --binary` to skip binary files would silently pass the very files we want to catch. The BOM patterns themselves do not appear in legitimate binary files (images, compiled outputs, etc.), so checking all changed files is safe.

## Files changed

- `.github/workflows/encoding-check.yml` - new workflow
- `workflow-docs/encoding-check.md` - documentation
- `README.md` - added row to Canonical Workflow Reference table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated encoding validation for pull requests to prevent UTF-16 and UTF-8 BOM encoded files from being merged.

* **Documentation**
  * Updated workflow reference guide and added comprehensive documentation for the new encoding validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->