### PR TITLE
fix(ci): replace broken codeql-action v4 SHAs with valid v3 pin

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@60168ffe96596fce55ee3851b6bb7b2e1ea8dbb0  # v4.35.1
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
         with:
           sarif_file: results.sarif
           category: codacy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
+      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
+      uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
@@ -73,6 +73,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
+      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         args: '. --sarif --output results.sarif'
     - name: Upload njsscan report
-      uses: github/codeql-action/upload-sarif@60168ffe96596fce55ee3851b6bb7b2e1ea8dbb0  # v4.35.1
+      uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
       if: steps.njsscan.outcome == 'success'
       with:
         sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,6 +50,6 @@ jobs:
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Fixes broken `github/codeql-action` SHAs in four workflows. Resolves #86.

## Problem

The `v4.35.1` and `v4.34.1` SHAs pinned in three workflows are no longer resolvable - they became invalid after a history rewrite in the `github/codeql-action` repo. GitHub Actions fails immediately with:

```
Unable to resolve action `github/codeql-action/upload-sarif@60168ffe...`, unable to find version `60168ffe...`
```

## Fix

Replace all broken SHAs with the confirmed-working v3 SHA already in use in `dockerfile-linter.yml`:

`5c8a8a642e79153f5d047b10ec1cba1d1cc65699` (`# v3`)

## Files changed

| File | Steps updated | Old SHA |
|------|--------------|---------|
| `codacy.yml` | `upload-sarif` | `60168ffe` (v4.35.1) |
| `njsscan.yml` | `upload-sarif` | `60168ffe` (v4.35.1) |
| `codeql.yml` | `init`, `autobuild`, `analyze` | `c10b8064` (v4.35.1) |
| `scorecard.yml` | `upload-sarif` | `38697555` (v4.34.1) |

`dockerfile-linter.yml` was already correct and is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code security scanning and analysis workflows to use the latest tool versions for improved reliability and consistency across the development pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->