### PR TITLE
feat(ci): replace legacy node.js.yml with reusable node-ci.yml and synced caller stub

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable Node.js CI workflow: build, lint, and test.
+# Called by consumer repos via a thin stub (node.js.yml) that uses this workflow.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Node.js CI (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  NPM_SCOPE: "@tazama-lf"
+  NPM_REGISTRY: "https://npm.pkg.github.com/"
+  NODE_ENV: 'test'
+
+jobs:
+  build:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    name: run build
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Use Node.js 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: ${{ env.NPM_REGISTRY }}
+          scope: ${{ env.NPM_SCOPE }}
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run build
+        run: npm run build
+
+  lint:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    name: check style
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Use Node.js 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: ${{ env.NPM_REGISTRY }}
+          scope: ${{ env.NPM_SCOPE }}
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check linting
+        run: npm run lint
+
+  test:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    name: check tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Use Node.js 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: ${{ env.NPM_REGISTRY }}
+          scope: ${{ env.NPM_SCOPE }}
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches: [ "dev", "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   node-ci:
     uses: tazama-lf/workflows/.github/workflows/node-ci.yml@dev

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,86 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+# Caller stub: delegates all Node.js CI logic to the centralised reusable workflow.
+# Logic changes belong in node-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
 name: Node.js CI
-
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NPM_SCOPE: "@frmscoe"
-  NPM_REGISTRY: "https://npm.pkg.github.com/"
-  NODE_ENV: 'test'
-  STARTUP_TYPE: 'nats'
 
 on:
   push:
     branches: [ "dev", "main" ]
   pull_request:
     branches: [ "dev", "main" ]
+
 jobs:
-  build:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    name: run build
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          registry-url: ${{ env.NPM_REGISTRY }}
-          scope: ${{ env.NPM_SCOPE }}
-      - name: Install dependencies 
-        run: npm ci
-      - name: Run build
-        run: npm run build
-
-  lint:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    name: check style
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          registry-url: ${{ env.NPM_REGISTRY }}
-          scope: ${{ env.NPM_SCOPE }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Check linting
-        run: npm run lint
-
-  test:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    name: check tests
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          registry-url: ${{ env.NPM_REGISTRY }}
-          scope: ${{ env.NPM_SCOPE }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Run tests
-        run: npm test
+  node-ci:
+    uses: tazama-lf/workflows/.github/workflows/node-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -153,7 +153,7 @@ jobs:
           mkdir -p temp-workflows
           cp -r .github/workflows/* temp-workflows/
           rm temp-workflows/sync-workflows.yml  # Remove the sync-workflows.yml to avoid recursive syncing
-          rm -f temp-workflows/node.js.yml  # Remove per-repo CI workflow to avoid overwriting repo-specific benchmarks
+          rm -f temp-workflows/node-ci.yml           # Reusable workflow: called by reference from node.js.yml stub; consumer repos don't need a local copy
           rm -f temp-workflows/dockerhub-image-build-dual.yml     # Dual-container Docker workflows: never synced; committed directly to target repos
           rm -f temp-workflows/dockerhub-image-build-dual-rc.yml  # Dual-container Docker workflows: never synced; committed directly to target repos
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following checks run automatically on pull requests across all repo classes.
 | `codeql.yml` | GitHub CodeQL SAST security scan |
 | `njsscan.yml` | Node.js-specific security scan (semgrep rules) |
 | `dependency-review.yml` | Flags new dependencies with known CVEs or licence restrictions |
-| `node.js.yml` | Build, lint, and test on Node 20 - **not synced; each repo maintains its own copy** |
+| `node.js.yml` | Build, lint, and test on Node 20 - caller stub; delegates to `node-ci.yml` (synced to all repos) |
 
 > Pre-commit tooling (local linting, formatting, commit-msg hooks) is developer-local and not managed here. See the project [contribution guide](https://github.com/tazama-lf/tazama-documentation) for local setup guidance.
 
@@ -212,7 +212,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `gpg-verify.yml` | Verify GPG signature on commits | `pull_request` | All repos |
 | `milestone.yml` | Close a milestone and trigger `release.yml` | `workflow_dispatch` | All repos |
 | `njsscan.yml` | Node.js security scan (semgrep) | `push`, `pull_request` | All repos |
-| `node.js.yml` | Node 20 CI: build, lint, test | `push: [dev,main]`, `pull_request: [dev,main]` | **Not synced** - each repo maintains its own copy |
+| `node-ci.yml` | Reusable: Node 20 CI: build, lint, test | `workflow_call` | **Not synced** - stays in this repo; called at runtime via `@dev` ref |\n| `node.js.yml` | Caller stub: delegates Node 20 CI to `node-ci.yml` | `push: [dev,main]`, `pull_request: [dev,main]` | All repos |
 | `package-rule-rc.yml` | Reusable: build and push `:rc` Docker image for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `package-rule.yml` | Reusable: build and push `:latest`/`:X.Y.Z` Docker images for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `library-dependency-rollout.yml` | On rc version merge to `dev` in a library repo, update the exact version pin in every registered consumer's `package.json`, regenerate `package-lock.json`, and open (or update) a `dep/library-dependency-bump → dev` PR | `push: [dev]` (path: `package.json`), `workflow_dispatch` | `PUBLISH_REPOS` only |
@@ -242,7 +242,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | File | Reason |
 |------|--------|
 | `sync-workflows.yml` | Canonical-only; never distributed to target repos |
-| `node.js.yml` | Each repo maintains its own copy to allow per-repo customisation |
+| `node-ci.yml` | Reusable workflow; stays in this repo and is called by the `node.js.yml` stub at runtime via `@dev` ref |
 
 **Full `REPOS` list (32 repos):** `relay-service`, `auth-service`, `typology-processor`, `event-director`, `event-sidecar`, `lumberjack`, `nats-utilities`, `batch-ppa`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `Full-Stack-Docker-Tazama`, `rule-executer`, `event-flow`, `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `rule-901`, `rule-902`, `tcs-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq`, `audit-lib`, `data-enrichment-service`, `event-monitoring-service`, `case-management-system`, `connection-studio`, `rule-studio`, `biar`.
 

--- a/workflow-docs/node-ci.md
+++ b/workflow-docs/node-ci.md
@@ -1,0 +1,106 @@
+# `node-ci.yml`
+
+## Purpose
+
+Reusable Node.js CI pipeline with three parallel jobs - build, lint, and test - running against Node.js 20. Contains all CI logic for Node.js consumer repos. Called by the [`node.js.yml`](nodejs.md) caller stub which is synced to all consumer repos.
+
+This file is **not synced** to consumer repos - it stays in `tazama-lf/workflows` and is referenced by the stub at runtime via `uses: tazama-lf/workflows/.github/workflows/node-ci.yml@dev`.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `workflow_call` | Called by `node.js.yml` stub in consumer repos |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Typical duration | ~2-5 min |
+| Concurrency | none |
+| Permissions | `contents: read` |
+
+---
+
+## Environment Variables
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `NPM_SCOPE` | `@tazama-lf` | npm scope for GitHub Packages registry routing |
+| `NPM_REGISTRY` | `https://npm.pkg.github.com/` | GitHub Packages registry URL |
+| `NODE_ENV` | `test` | sets test environment for all jobs |
+
+---
+
+## Jobs
+
+### `build` - run build
+
+**Condition:** `github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'`
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
+2. `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0) - Node 20, npm cache, registry and scope
+3. `npm ci` (authenticated via `NODE_AUTH_TOKEN: secrets.GITHUB_TOKEN`)
+4. `npm run build`
+
+### `lint` - check style
+
+**Condition:** `github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'`
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
+2. `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0)
+3. `npm ci` (authenticated via `NODE_AUTH_TOKEN: secrets.GITHUB_TOKEN`)
+4. `npm run lint`
+
+### `test` - check tests
+
+**Condition:** `github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'`
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
+2. `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0)
+3. `npm ci` (authenticated via `NODE_AUTH_TOKEN: secrets.GITHUB_TOKEN`)
+4. `npm test`
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `GITHUB_TOKEN` | auto | npm authentication for GitHub Packages (`NODE_AUTH_TOKEN` per step) |
+
+Secrets are forwarded from the caller stub via `secrets: inherit`.
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| **All repos** | **Not synced** - reusable workflow stays in `tazama-lf/workflows` only; consumer repos reference it by the `@dev` branch ref at runtime |
+
+The caller stub (`node.js.yml`) is what gets synced. See [`nodejs.md`](nodejs.md).
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
+| `actions/setup-node` | `53b83947a5a98c8d113130e565377fae1a50d02f` | v6.3.0 |
+
+---
+
+## Known Limitations / Notes
+
+- All three jobs run in parallel; there is no dependency between them.
+- `npm run lint` is expected to run both ESLint and Prettier checks (`lint:eslint && lint:prettier`). Repos that do not have a `lint` script will fail the lint job.
+- `npm run build` and `npm test` must be defined in the consumer repo's `package.json`.
+- `STARTUP_TYPE` and `GH_TOKEN` top-level env vars present in the legacy `node.js.yml` have been intentionally removed: `STARTUP_TYPE` was a leftover from integration test era (unit tests must be self-contained), and `GH_TOKEN` is replaced by the scoped `NODE_AUTH_TOKEN` pattern which is the correct approach for `actions/setup-node` registry authentication.

--- a/workflow-docs/nodejs.md
+++ b/workflow-docs/nodejs.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Node.js CI pipeline with three parallel jobs - build, lint, and test - running against Node.js 20. Validates that the project compiles, passes linting rules, and all tests pass on every push and pull request to `dev` and `main`.
+Caller stub that delegates Node.js CI to the centralised reusable workflow [`node-ci.yml`](node-ci.md). Contains only the push/PR triggers and a single `uses:` reference - no logic lives here. This file is synced to all consumer repos unchanged.
 
 ---
 
@@ -17,58 +17,36 @@ Node.js CI pipeline with three parallel jobs - build, lint, and test - running a
 
 ## Execution Context
 
-| Property | Value |
-|----------|-------|
-| Runner | `ubuntu-latest` |
-| Node version | `20` |
-| Typical duration | ~2–5 min |
-| Concurrency | none |
-| Permissions | default |
-
----
-
-## Environment Variables
-
-| Variable | Value | Purpose |
-|----------|-------|--------|
-| `GH_TOKEN` | `secrets.GITHUB_TOKEN` | npm auth for private packages |
-| `NPM_SCOPE` | `@frmscoe` | npm scope for registry routing |
-| `NPM_REGISTRY` | `https://npm.pkg.github.com/` | GitHub Packages registry |
-| `NODE_ENV` | `test` | sets test environment |
-| `STARTUP_TYPE` | `nats` | messaging system type expected by some tests |
+All execution context is defined in [`node-ci.yml`](node-ci.md). This stub adds no jobs, steps, or environment variables of its own.
 
 ---
 
 ## Jobs
 
-### `build` - run build
+### `node-ci`
 
-1. `actions/checkout@v4`
-2. `actions/setup-node@v4` - Node 20, npm cache, registry and scope
-3. `npm ci`
-4. `npm run build`
+Delegates entirely to the reusable workflow:
 
-### `lint` - check style
+```yaml
+uses: tazama-lf/workflows/.github/workflows/node-ci.yml@dev
+secrets: inherit
+```
 
-1. `actions/checkout@v4`
-2. `actions/setup-node@v4`
-3. `npm ci`
-4. `npm run lint`
-
-### `test` - check tests
-
-1. `actions/checkout@v4`
-2. `actions/setup-node@v4`
-3. `npm ci`
-4. `npm test`
+See [`node-ci.yml` documentation](node-ci.md) for the full job breakdown.
 
 ---
 
 ## Required Secrets
 
-| Secret | Scope | Purpose |
-|--------|-------|-------|
-| `GITHUB_TOKEN` | auto | npm authentication via `GH_TOKEN` |
+All secrets are passed through via `secrets: inherit`. See [`node-ci.yml`](node-ci.md) for the list.
+
+---
+
+## Permissions
+
+| Scope | Level |
+|-------|-------|
+| `contents` | `read` |
 
 ---
 
@@ -76,27 +54,20 @@ Node.js CI pipeline with three parallel jobs - build, lint, and test - running a
 
 | Group | Behaviour |
 |-------|----------|
-| **All repos** | **Excluded from sync** - `node.js.yml` is explicitly removed before the sync bundle is assembled; every repo maintains its own copy |
+| **All repos** | Synced - identical stub distributed to all 32 consumer repos |
+
+Because the stub is static (it always points to `@dev`), subsequent syncs will skip repos where the file is already up to date.
 
 ---
 
 ## Dependencies (pinned actions)
 
-| Action | Pinned SHA | Semver alias |
-|--------|-----------|----------|
-| `actions/checkout` | tag ref `v4` | - |
-| `actions/setup-node` | tag ref `v4` | - |
+None - this file contains no `uses:` action steps, only the reusable workflow reference.
 
 ---
 
 ## Known Limitations / Notes
 
-- Excluded from sync to preserve per-repo customisations (some repos have additional jobs or environment-specific configurations). Any changes to the canonical file must be propagated manually to each repo (see `update-workflows.md` Track A6 / Track B4).
-- `NPM_SCOPE` is set to `@frmscoe`; this is intentional as many private packages are still published under the `@frmscoe` scope.
-- `dependabot[bot]` actors are excluded.
-
----
-
-## Repository Overrides
-
-Not applicable - this workflow is not synced; every repo maintains its own copy. Some repos previously had a `bench` job included in this file; that job is being removed via separate PRs.
+- Logic changes belong in [`node-ci.yml`](node-ci.md), not here.
+- `dependabot[bot]` actor exclusions are enforced inside `node-ci.yml`.
+- The stub is identical across all consumer repos; repo-specific CI behaviour is not supported under this pattern. If a repo genuinely needs different CI behaviour it should maintain its own workflow and opt out of the sync for that file.


### PR DESCRIPTION
## Summary

Pilots the reusable workflow + synced stub pattern (ref issue #94) for Node.js CI.

Closes #93

## Changes

### New: `node-ci.yml` (reusable, NOT synced)

Central CI logic with `on: workflow_call`. Fixes carried forward from the legacy workflow:

- `NPM_SCOPE` corrected from `@frmscoe` to `@tazama-lf`
- `STARTUP_TYPE: nats` removed - not needed for unit tests (was a leftover from integration test era)
- `GH_TOKEN` top-level env var removed - replaced with `NODE_AUTH_TOKEN` scoped per `npm ci` step (correct pattern for GitHub Packages auth)
- Node 16 matrix dropped - EOL
- `permissions: contents: read` added
- SHA-pinned actions retained (same SHAs as canonical)

### Modified: `node.js.yml` (caller stub, synced to all repos)

Reduced to 18 lines. Declares the push/PR triggers and delegates everything to `node-ci.yml@dev`:

```yaml
jobs:
  node-ci:
    uses: tazama-lf/workflows/.github/workflows/node-ci.yml@dev
    secrets: inherit
```

Consumer repos get this stub via sync. Because the stub just points at `@dev`, any future fix to `node-ci.yml` takes effect immediately in all repos with no further sync PRs.

### Modified: `sync-workflows.yml`

- Removes `rm -f temp-workflows/node.js.yml` (stub is now safe to sync)
- Adds `rm -f temp-workflows/node-ci.yml` (reusable workflow stays in canonical repo only)

## Testing

On merge to `dev`, the `node.js.yml` stub in this repo will execute and invoke `node-ci.yml` - this is the live smoke test for the pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI was centralized to a reusable Node.js workflow and caller workflows simplified to delegate to it, reducing duplication.
  * Repository sync was updated to exclude the temporary reusable workflow from propagated bundles to avoid unintended copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->