### PR TITLE
fix(ci): add issues:write permission for label management

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   validate-pr-title:

--- a/.github/workflows/library-dependency-rollout.yml
+++ b/.github/workflows/library-dependency-rollout.yml
@@ -101,7 +101,7 @@ jobs:
         if: steps.check_rc.outputs.skip != 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Fetch consumer catalog
         if: steps.check_rc.outputs.skip != 'true'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 env:
   NPM_SCOPE: "@tazama-lf"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -27,10 +27,10 @@ jobs:
     name: run build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: ${{ env.NPM_SCOPE }}
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: ${{ env.NPM_SCOPE }}
@@ -69,10 +69,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: ${{ env.NPM_SCOPE }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   node-ci:

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Read rule version from package.json
         id: rule_version

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Read rule version from package.json
         id: rule_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com/'
           scope: '@tazama-lf'
 

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com/'
           scope: '@tazama-lf'
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following checks run automatically on pull requests across all repo classes.
 | `codeql.yml` | GitHub CodeQL SAST security scan |
 | `njsscan.yml` | Node.js-specific security scan (semgrep rules) |
 | `dependency-review.yml` | Flags new dependencies with known CVEs or licence restrictions |
-| `node.js.yml` | Build, lint, and test on Node 20 - caller stub; delegates to `node-ci.yml` (synced to all repos) |
+| `node.js.yml` | Build, lint, and test on Node 22 LTS - caller stub; delegates to `node-ci.yml` (synced to all repos) |
 
 > Pre-commit tooling (local linting, formatting, commit-msg hooks) is developer-local and not managed here. See the project [contribution guide](https://github.com/tazama-lf/tazama-documentation) for local setup guidance.
 
@@ -212,7 +212,7 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `gpg-verify.yml` | Verify GPG signature on commits | `pull_request` | All repos |
 | `milestone.yml` | Close a milestone and trigger `release.yml` | `workflow_dispatch` | All repos |
 | `njsscan.yml` | Node.js security scan (semgrep) | `push`, `pull_request` | All repos |
-| `node-ci.yml` | Reusable: Node 20 CI: build, lint, test | `workflow_call` | **Not synced** - stays in this repo; called at runtime via `@dev` ref |\n| `node.js.yml` | Caller stub: delegates Node 20 CI to `node-ci.yml` | `push: [dev,main]`, `pull_request: [dev,main]` | All repos |
+| `node-ci.yml` | Reusable: Node 22 LTS CI: build, lint, test | `workflow_call` | **Not synced** - stays in this repo; called at runtime via `@dev` ref |\n| `node.js.yml` | Caller stub: delegates Node 22 LTS CI to `node-ci.yml` | `push: [dev,main]`, `pull_request: [dev,main]` | All repos |
 | `package-rule-rc.yml` | Reusable: build and push `:rc` Docker image for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `package-rule.yml` | Reusable: build and push `:latest`/`:X.Y.Z` Docker images for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `library-dependency-rollout.yml` | On rc version merge to `dev` in a library repo, update the exact version pin in every registered consumer's `package.json`, regenerate `package-lock.json`, and open (or update) a `dep/library-dependency-bump → dev` PR | `push: [dev]` (path: `package.json`), `workflow_dispatch` | `PUBLISH_REPOS` only |
@@ -342,11 +342,11 @@ Most workflow files pin external actions to commit SHAs for supply-chain securit
 
 ### Node.js version updates
 
-`node.js.yml` is not synced and must be updated in each repo individually.
+`node-ci.yml` is the single place to update the Node.js version. It is **not synced** to target repos - it stays in this repo and is called at runtime via `@dev` ref by the `node.js.yml` caller stub in every target repo. Bumping the version here takes effect immediately on the next workflow run in all repos without requiring any sync PR.
 
-1. Update the canonical `.github/workflows/node.js.yml` in this repo.
-2. Apply the same change to each repo in `REPOS`, to `frmscoe/workflows`, and its 33 target repos.
-3. Track progress in `update-workflows.md` (private planning doc, not committed to this repo).
+1. Update `node-version:` in all three jobs (`build`, `lint`, `test`) in `.github/workflows/node-ci.yml`.
+2. Update the step names (`Use Node.js XX`) to match.
+3. Open a PR to `dev` in this repo.
 
 ### gh CLI version
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 | `gpg-verify.yml` | Verify GPG signature on commits | `pull_request` | All repos |
 | `milestone.yml` | Close a milestone and trigger `release.yml` | `workflow_dispatch` | All repos |
 | `njsscan.yml` | Node.js security scan (semgrep) | `push`, `pull_request` | All repos |
-| `node-ci.yml` | Reusable: Node 22 LTS CI: build, lint, test | `workflow_call` | **Not synced** - stays in this repo; called at runtime via `@dev` ref |\n| `node.js.yml` | Caller stub: delegates Node 22 LTS CI to `node-ci.yml` | `push: [dev,main]`, `pull_request: [dev,main]` | All repos |
+| `node-ci.yml` | Reusable: Node 22 LTS CI: build, lint, test | `workflow_call` | **Not synced** - stays in this repo; called at runtime via `@dev` ref |
+| `node.js.yml` | Caller stub: delegates Node 22 LTS CI to `node-ci.yml` | `push: [dev,main]`, `pull_request: [dev,main]` | All repos |
 | `package-rule-rc.yml` | Reusable: build and push `:rc` Docker image for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `package-rule.yml` | Reusable: build and push `:latest`/`:X.Y.Z` Docker images for a rule processor | `workflow_call` | Not synced directly; caller stubs distributed to `RULE_REPOS` |
 | `library-dependency-rollout.yml` | On rc version merge to `dev` in a library repo, update the exact version pin in every registered consumer's `package.json`, regenerate `package-lock.json`, and open (or update) a `dep/library-dependency-bump → dev` PR | `push: [dev]` (path: `package.json`), `workflow_dispatch` | `PUBLISH_REPOS` only |


### PR DESCRIPTION
## Summary

Adds `issues: write` permission to the PR Conventional Commits validation workflow.

## Problem

The `ytanikin/PRConventionalCommits` action uses `add_label: true`, which applies labels via GitHub's Issues API (`/repos/{owner}/{repo}/issues/{issue_number}/labels`). This endpoint requires `issues: write` scope on the GITHUB_TOKEN.

## Root cause

The org default workflow permissions were recently changed from "Read and write" to "Read repository contents only". Previously, unlisted permissions leaked through from the org default. Now the explicit `permissions:` block is a hard ceiling, and `issues: write` was not listed.

## Change

Added `issues: write` to the `permissions` block in `conventional-commits.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to run on Node.js 22.
  * Enhanced GitHub Actions permissions (added issues: write and packages: read).

* **Documentation**
  * Updated docs to reflect centralized Node.js version management and the new update process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->