### PR TITLE
ci: replace SSH_SIGNING_KEY with GitHub App token in library-dependency-rollout and sync-workflows

### DIFF
--- a/.github/workflows/library-dependency-rollout.yml
+++ b/.github/workflows/library-dependency-rollout.yml
@@ -43,6 +43,22 @@ jobs:
       contents: read
 
     steps:
+      - name: Generate GitHub App token (tazama-lf)
+        id: app_token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
+        with:
+          app-id: ${{ secrets.TAZAMA_BOT_APP_ID }}
+          private-key: ${{ secrets.TAZAMA_BOT_PRIVATE_KEY }}
+          owner: tazama-lf
+
+      - name: Generate GitHub App token (frmscoe)
+        id: app_token_frmscoe
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
+        with:
+          app-id: ${{ secrets.TAZAMA_BOT_APP_ID }}
+          private-key: ${{ secrets.TAZAMA_BOT_PRIVATE_KEY }}
+          owner: frmscoe
+
       - name: Checkout library repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -76,26 +92,11 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Git signing
+      - name: Set up Git identity
         if: steps.check_rc.outputs.skip != 'true'
         run: |
-          git config --global user.name 'Justus-at-Tazama'
-          git config --global user.email '123470803+Justus-at-Tazama@users.noreply.github.com'
-          git config --global credential.helper store
-          if [ -z "${{ secrets.SSH_SIGNING_KEY }}" ]; then
-            echo "::error::SSH_SIGNING_KEY secret is not set. Commits cannot be signed."
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_SIGNING_KEY }}" | base64 -d > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
-          ssh-keygen -y -f ~/.ssh/signing_key > /dev/null || {
-            echo "::error::SSH_SIGNING_KEY is not a valid SSH private key or is passphrase-protected."
-            exit 1
-          }
-          git config --global gpg.format ssh
-          git config --global user.signingkey ~/.ssh/signing_key
-          git config --global commit.gpgsign true
+          git config --global user.name 'tazama-lf-ci-bot[bot]'
+          git config --global user.email '282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com'
 
       - name: Set up Node.js
         if: steps.check_rc.outputs.skip != 'true'
@@ -106,7 +107,7 @@ jobs:
       - name: Fetch consumer catalog
         if: steps.check_rc.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           HTTP_STATUS=$(curl -s -o /tmp/catalog-response.json -w "%{http_code}" \
             -H "Authorization: token ${GH_TOKEN}" \
@@ -125,7 +126,8 @@ jobs:
       - name: Roll out to consumers
         if: steps.check_rc.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN_FRMSCOE: ${{ steps.app_token_frmscoe.outputs.token }}
           GH_TOKEN_LIB: ${{ secrets.GH_TOKEN_LIB }}
           PKG_NAME: ${{ steps.lib_pkg.outputs.name }}
           PKG_VERSION: ${{ steps.lib_pkg.outputs.version }}
@@ -134,7 +136,7 @@ jobs:
           set -euo pipefail
 
           BUMP_BRANCH="dep/library-dependency-bump"
-          SIGNED_OFF_BY="Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>"
+          SIGNED_OFF_BY="Signed-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>"
           WORK_DIR=$(mktemp -d)
 
           # Read consumers for this library from the catalog
@@ -159,13 +161,20 @@ jobs:
             REPO="${CONSUMER##*/}"
             REPO_DIR="${WORK_DIR}/${ORG}-${REPO}"
 
+            # Select the token for this consumer's org
+            if [ "$ORG" = "frmscoe" ]; then
+              ORG_TOKEN="${GH_TOKEN_FRMSCOE}"
+            else
+              ORG_TOKEN="${GH_TOKEN}"
+            fi
+
             echo ""
             echo "=== Processing ${ORG}/${REPO} ==="
 
             # Clone consumer repo
             if ! git clone \
                 --depth=50 \
-                "https://x-access-token:${GH_TOKEN}@github.com/${ORG}/${REPO}.git" \
+                "https://x-access-token:${ORG_TOKEN}@github.com/${ORG}/${REPO}.git" \
                 "${REPO_DIR}" 2>&1; then
               echo "::warning::Could not clone ${ORG}/${REPO}. Skipping."
               echo "| \`${CONSUMER}\` | ❌ Clone failed | Could not clone repo |" >> "$GITHUB_STEP_SUMMARY"
@@ -253,14 +262,14 @@ jobs:
               continue
             fi
 
-            # Commit with SSH signing
+            # Commit
             git commit \
-              -m "chore(deps): bump ${PKG_NAME} to ${PKG_VERSION}" \
+              -m "build(deps): bump ${PKG_NAME} to ${PKG_VERSION}" \
               -m "${SIGNED_OFF_BY}"
 
             # Push (force-with-lease to avoid overwriting concurrent pushes)
             if ! git push \
-                "https://x-access-token:${GH_TOKEN}@github.com/${ORG}/${REPO}.git" \
+                "https://x-access-token:${ORG_TOKEN}@github.com/${ORG}/${REPO}.git" \
                 "${BUMP_BRANCH}" \
                 --force-with-lease 2>&1; then
               echo "::warning::Push failed for ${ORG}/${REPO}. Another rollout may have pushed concurrently. Re-run this workflow to retry."
@@ -271,7 +280,7 @@ jobs:
 
             # Check for existing open PR from dep/library-dependency-bump → dev
             EXISTING_PR_URL=$(curl -sf \
-              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Authorization: token ${ORG_TOKEN}" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${ORG}/${REPO}/pulls?state=open&head=${ORG}:${BUMP_BRANCH}&base=dev" \
               | jq -r '.[0].html_url // ""')
@@ -283,7 +292,7 @@ jobs:
               # Build PR body listing current bump plus any prior bumps already on the branch
               # Collect all chore(deps): bump commits on this branch not on dev
               PRIOR_BUMPS=$(git log "origin/dev..HEAD" --format="%s" 2>/dev/null \
-                | grep -E '^chore\(deps\): bump ' \
+                | grep -E '^build\(deps\): bump ' \
                 | grep -v "bump ${PKG_NAME}" \
                 || true)
 
@@ -301,21 +310,21 @@ jobs:
                 if [ -n "$PRIOR_BUMPS" ]; then
                   while IFS= read -r line; do
                     # Extract "bump <pkg> to <ver>" from commit subject
-                    BUMP_PKG=$(echo "$line" | sed 's/chore(deps): bump \(.*\) to .*/\1/')
-                    BUMP_VER=$(echo "$line" | sed 's/chore(deps): bump .* to \(.*\)/\1/')
+                    BUMP_PKG=$(echo "$line" | sed 's/build(deps): bump \(.*\) to .*/\1/')
+                    BUMP_VER=$(echo "$line" | sed 's/build(deps): bump .* to \(.*\)/\1/')
                     echo "| \`${BUMP_PKG}\` | \`${BUMP_VER}\` |"
                   done <<< "$PRIOR_BUMPS"
                 fi
                 echo ""
                 echo "> \`package-lock.json\` has been regenerated. Run \`npm install\` locally to sync your working copy after merging."
                 echo ""
-                echo "Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>"
+                echo "Signed-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>"
               } > "$PR_BODY_FILE"
 
               # Create PR
               PR_PAYLOAD_FILE=$(mktemp)
               jq -n \
-                --arg title "chore(deps): bump library dependencies" \
+                --arg title "build(deps): bump library dependencies" \
                 --arg body "$(cat "$PR_BODY_FILE")" \
                 --arg head "${BUMP_BRANCH}" \
                 --arg base "dev" \
@@ -324,7 +333,7 @@ jobs:
 
               CREATE_RESPONSE=$(curl -sf \
                 -X POST \
-                -H "Authorization: token ${GH_TOKEN}" \
+                -H "Authorization: token ${ORG_TOKEN}" \
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Content-Type: application/json" \
                 --data "@${PR_PAYLOAD_FILE}" \
@@ -342,7 +351,7 @@ jobs:
                   REVIEWER_PAYLOAD=$(jq -n --arg r "$PR_REVIEWERS" '{reviewers: [$r]}')
                   curl -sf \
                     -X POST \
-                    -H "Authorization: token ${GH_TOKEN}" \
+                    -H "Authorization: token ${ORG_TOKEN}" \
                     -H "Accept: application/vnd.github.v3+json" \
                     -H "Content-Type: application/json" \
                     -d "$REVIEWER_PAYLOAD" \

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -25,51 +25,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Git  # Step to configure Git with necessary details
-        run: |
-          git config --global user.name 'Justus-at-Tazama'
-          git config --global user.email '123470803+Justus-at-Tazama@users.noreply.github.com'
-          git config --global credential.helper store
-          # Configure SSH commit signing so sync commits show as Verified on GitHub.
-          # SSH_SIGNING_KEY must be stored base64-encoded (single line, no wrapping) to avoid
-          # line-ending corruption. Set with: base64 -w 0 signing_key | gh secret set SSH_SIGNING_KEY
-          # The corresponding public key must be registered as a Signing Key on the GitHub account
-          # that GH_TOKEN belongs to: Settings → SSH and GPG keys → New signing key.
-          if [ -z "${{ secrets.SSH_SIGNING_KEY }}" ]; then
-            echo "::error::SSH_SIGNING_KEY secret is not set. Commits cannot be signed. Add the secret before running the sync." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          # Decode the base64 secret directly to the key file - no line-ending issues possible.
-          echo "${{ secrets.SSH_SIGNING_KEY }}" | base64 -d > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
-          # Validate the key is a usable Ed25519/RSA private key before enabling signing.
-          ssh-keygen -y -f ~/.ssh/signing_key > /dev/null || {
-            echo "::error::SSH_SIGNING_KEY is not a valid SSH private key or is passphrase-protected. Fix the secret before running the sync." >&2
-            exit 1
-          }
-          git config --global gpg.format ssh
-          git config --global user.signingkey ~/.ssh/signing_key
-          git config --global commit.gpgsign true
+      - name: Generate GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
+        with:
+          app-id: ${{ secrets.TAZAMA_BOT_APP_ID }}
+          private-key: ${{ secrets.TAZAMA_BOT_PRIVATE_KEY }}
+          owner: tazama-lf
 
-      - name: Get actor details  # Step to get the triggering actor's details for the Signed-off-by line
-        id: pr_author
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Git identity
         run: |
-          # For pull_request events use the PR author login; for push/workflow_dispatch fall back to the triggering actor.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_AUTHOR_NAME=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.user.login')
-            PR_AUTHOR_NAME_FULL=$(git log -1 --pretty=format:'%an')
-            PR_AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
-          else
-            PR_AUTHOR_NAME="${{ github.actor }}"
-            PR_AUTHOR_NAME_FULL="${{ github.actor }}"
-            PR_AUTHOR_EMAIL="${{ github.actor }}@users.noreply.github.com"
-          fi
-          echo "PR_AUTHOR_NAME=${PR_AUTHOR_NAME}" >> $GITHUB_ENV
-          echo "PR_AUTHOR_EMAIL=${PR_AUTHOR_EMAIL}" >> $GITHUB_ENV
-          echo "PR_AUTHOR_NAME_FULL=${PR_AUTHOR_NAME_FULL}" >> $GITHUB_ENV
+          git config --global user.name 'tazama-lf-ci-bot[bot]'
+          git config --global user.email '282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com'
 
       - name: Sync Workflows to Other Repos  # Step to sync workflows to other repositories
         env:
@@ -145,9 +112,9 @@ jobs:
             rule-901
             rule-902
           PR_REVIEWERS: ${{ secrets.GH_USERNAME }}  # List of reviewers
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          SIGNED_OFF_BY="Signed-off-by: ${{ env.PR_AUTHOR_NAME_FULL }} <${{ env.PR_AUTHOR_EMAIL }}>"
+          SIGNED_OFF_BY="Signed-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>"
 
           # Capture the workspace root so we can reference config-templates/ after cd-ing into each repo
           WORKFLOWS_ROOT="${GITHUB_WORKSPACE}"
@@ -170,7 +137,7 @@ jobs:
 
             git clone https://github.com/$ORG/$repo.git
             cd $repo
-            git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/$ORG/$repo.git
+            git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$ORG/$repo.git
 
             # Ensure dev branch exists in target repo - create from default branch if absent.
             if ! git ls-remote --heads origin dev | grep -q dev; then


### PR DESCRIPTION
## Summary

Replaces the user-bound `SSH_SIGNING_KEY` approach with a GitHub App token (`tazama-lf-ci-bot`), making the workflows org-bound rather than tied to a specific user.

Closes #103
Closes #106

## Changes

### library-dependency-rollout.yml
- Added two `actions/create-github-app-token` steps - one for `tazama-lf`, one for `frmscoe` (the app is installed on both orgs)
- Removed "Set up Git signing" step and all `SSH_SIGNING_KEY` references
- Git identity now uses `tazama-lf-ci-bot[bot]` with the correct numeric noreply email
- Consumer org token is selected per-loop: `frmscoe` consumers use the frmscoe installation token, all others use the tazama-lf token
- Commit and PR titles changed from `chore(deps):` to `build(deps):` to match Tazama conventional commit types

### sync-workflows.yml
- Added `actions/create-github-app-token` step for `tazama-lf` org (sync only targets tazama-lf repos)
- Removed "Set up Git" SSH signing block and "Get actor details" step
- Git identity now uses `tazama-lf-ci-bot[bot]`
- All clone, push, and `gh` CLI calls use the app token via `GH_TOKEN` env var

## Why two tokens for rollout, one for sync?

A GitHub App installation token is scoped to the org it was generated for. The rollout workflow pushes to repos in both `tazama-lf` and `frmscoe`, so it needs one token per org. The sync workflow only targets `tazama-lf` repos, so one token is sufficient.

## Prerequisites (already done)

- `tazama-lf-ci-bot` GitHub App created in `tazama-lf` org (App ID: 3643676)
- App installed on both `tazama-lf` and `frmscoe` orgs (all repositories)
- `TAZAMA_BOT_APP_ID` and `TAZAMA_BOT_PRIVATE_KEY` added as org-level secrets on both orgs