### PR TITLE
ci: use SSH signing for library-dependency-rollout; revert sync-workflows to SSH signing

### DIFF
--- a/.github/workflows/library-dependency-rollout.yml
+++ b/.github/workflows/library-dependency-rollout.yml
@@ -43,22 +43,6 @@ jobs:
       contents: read
 
     steps:
-      - name: Generate GitHub App token (tazama-lf)
-        id: app_token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
-        with:
-          app-id: ${{ secrets.TAZAMA_BOT_APP_ID }}
-          private-key: ${{ secrets.TAZAMA_BOT_PRIVATE_KEY }}
-          owner: tazama-lf
-
-      - name: Generate GitHub App token (frmscoe)
-        id: app_token_frmscoe
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
-        with:
-          app-id: ${{ secrets.TAZAMA_BOT_APP_ID }}
-          private-key: ${{ secrets.TAZAMA_BOT_PRIVATE_KEY }}
-          owner: frmscoe
-
       - name: Checkout library repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -92,11 +76,30 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Git identity
+      - name: Set up Git signing
         if: steps.check_rc.outputs.skip != 'true'
         run: |
-          git config --global user.name 'tazama-lf-ci-bot[bot]'
-          git config --global user.email '282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com'
+          git config --global user.name 'Justus-at-Tazama'
+          git config --global user.email '123470803+Justus-at-Tazama@users.noreply.github.com'
+          git config --global credential.helper store
+          # Configure SSH commit signing so rollout commits show as Verified on GitHub.
+          # SSH_SIGNING_KEY is stored base64-encoded as an org-level secret (all repos).
+          # The corresponding public key must be registered as a Signing Key on the GitHub account
+          # that GH_TOKEN belongs to: Settings -> SSH and GPG keys -> New signing key.
+          if [ -z "${{ secrets.SSH_SIGNING_KEY }}" ]; then
+            echo "::error::SSH_SIGNING_KEY secret is not set. Commits cannot be signed." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_SIGNING_KEY }}" | base64 -d > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          ssh-keygen -y -f ~/.ssh/signing_key > /dev/null || {
+            echo "::error::SSH_SIGNING_KEY is not a valid SSH private key or is passphrase-protected." >&2
+            exit 1
+          }
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/signing_key
+          git config --global commit.gpgsign true
 
       - name: Set up Node.js
         if: steps.check_rc.outputs.skip != 'true'
@@ -126,8 +129,8 @@ jobs:
       - name: Roll out to consumers
         if: steps.check_rc.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          GH_TOKEN_FRMSCOE: ${{ steps.app_token_frmscoe.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN_FRMSCOE: ${{ secrets.GH_TOKEN }}
           GH_TOKEN_LIB: ${{ secrets.GH_TOKEN_LIB }}
           PKG_NAME: ${{ steps.lib_pkg.outputs.name }}
           PKG_VERSION: ${{ steps.lib_pkg.outputs.version }}
@@ -136,7 +139,7 @@ jobs:
           set -euo pipefail
 
           BUMP_BRANCH="dep/library-dependency-bump"
-          SIGNED_OFF_BY="Signed-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>"
+          SIGNED_OFF_BY="Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>"
           WORK_DIR=$(mktemp -d)
 
           # Read consumers for this library from the catalog
@@ -318,7 +321,7 @@ jobs:
                 echo ""
                 echo "> \`package-lock.json\` has been regenerated. Run \`npm install\` locally to sync your working copy after merging."
                 echo ""
-                echo "Signed-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>"
+                echo "Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>"
               } > "$PR_BODY_FILE"
 
               # Create PR

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -25,18 +25,51 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Generate GitHub App token
-        id: app_token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
-        with:
-          app-id: ${{ secrets.TAZAMA_BOT_APP_ID }}
-          private-key: ${{ secrets.TAZAMA_BOT_PRIVATE_KEY }}
-          owner: tazama-lf
-
-      - name: Set up Git identity
+      - name: Set up Git  # Step to configure Git with necessary details
         run: |
-          git config --global user.name 'tazama-lf-ci-bot[bot]'
-          git config --global user.email '282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com'
+          git config --global user.name 'Justus-at-Tazama'
+          git config --global user.email '123470803+Justus-at-Tazama@users.noreply.github.com'
+          git config --global credential.helper store
+          # Configure SSH commit signing so sync commits show as Verified on GitHub.
+          # SSH_SIGNING_KEY must be stored base64-encoded (single line, no wrapping) to avoid
+          # line-ending corruption. Set with: base64 -w 0 signing_key | gh secret set SSH_SIGNING_KEY
+          # The corresponding public key must be registered as a Signing Key on the GitHub account
+          # that GH_TOKEN belongs to: Settings -> SSH and GPG keys -> New signing key.
+          if [ -z "${{ secrets.SSH_SIGNING_KEY }}" ]; then
+            echo "::error::SSH_SIGNING_KEY secret is not set. Commits cannot be signed. Add the secret before running the sync." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          # Decode the base64 secret directly to the key file - no line-ending issues possible.
+          echo "${{ secrets.SSH_SIGNING_KEY }}" | base64 -d > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          # Validate the key is a usable Ed25519/RSA private key before enabling signing.
+          ssh-keygen -y -f ~/.ssh/signing_key > /dev/null || {
+            echo "::error::SSH_SIGNING_KEY is not a valid SSH private key or is passphrase-protected. Fix the secret before running the sync." >&2
+            exit 1
+          }
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/signing_key
+          git config --global commit.gpgsign true
+
+      - name: Get actor details  # Step to get the triggering actor's details for the Signed-off-by line
+        id: pr_author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # For pull_request events use the PR author login; for push/workflow_dispatch fall back to the triggering actor.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_AUTHOR_NAME=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.user.login')
+            PR_AUTHOR_NAME_FULL=$(git log -1 --pretty=format:'%an')
+            PR_AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
+          else
+            PR_AUTHOR_NAME="${{ github.actor }}"
+            PR_AUTHOR_NAME_FULL="${{ github.actor }}"
+            PR_AUTHOR_EMAIL="${{ github.actor }}@users.noreply.github.com"
+          fi
+          echo "PR_AUTHOR_NAME=${PR_AUTHOR_NAME}" >> $GITHUB_ENV
+          echo "PR_AUTHOR_EMAIL=${PR_AUTHOR_EMAIL}" >> $GITHUB_ENV
+          echo "PR_AUTHOR_NAME_FULL=${PR_AUTHOR_NAME_FULL}" >> $GITHUB_ENV
 
       - name: Sync Workflows to Other Repos  # Step to sync workflows to other repositories
         env:
@@ -112,9 +145,9 @@ jobs:
             rule-901
             rule-902
           PR_REVIEWERS: ${{ secrets.GH_USERNAME }}  # List of reviewers
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          SIGNED_OFF_BY="Signed-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>"
+          SIGNED_OFF_BY="Signed-off-by: ${{ env.PR_AUTHOR_NAME_FULL }} <${{ env.PR_AUTHOR_EMAIL }}>"
 
           # Capture the workspace root so we can reference config-templates/ after cd-ing into each repo
           WORKFLOWS_ROOT="${GITHUB_WORKSPACE}"
@@ -137,7 +170,7 @@ jobs:
 
             git clone https://github.com/$ORG/$repo.git
             cd $repo
-            git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$ORG/$repo.git
+            git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/$ORG/$repo.git
 
             # Ensure dev branch exists in target repo - create from default branch if absent.
             if ! git ls-remote --heads origin dev | grep -q dev; then


### PR DESCRIPTION
## Summary

Replaces the GitHub App token approach (PR #105) with SSH commit signing - the same pattern that `sync-workflows.yml` was already using successfully.\n\n## Changes\n\n### library-dependency-rollout.yml\n- Remove both `actions/create-github-app-token` steps\n- Add "Set up Git signing" step using `SSH_SIGNING_KEY` org secret (same pattern as sync-workflows)\n- Restore `GH_TOKEN: ${{ secrets.GH_TOKEN }}` for both tazama-lf and frmscoe consumers (a PAT works cross-org)\n- Restore `Justus-at-Tazama` identity and Signed-off-by\n\n### sync-workflows.yml\n- Revert from GitHub App token back to SSH signing (undoes the change from PR #105)\n\n## Why\n\nGitHub Apps making commits via `git commit` produce unverified commits when "Require signed commits" branch protection is active. The correct solution is SSH signing with a key registered on a GitHub account - which is what sync-workflows was already doing. `SSH_SIGNING_KEY` has now been promoted from a repo-level secret on `tazama-lf/workflows` to an org-level secret on both `tazama-lf` and `frmscoe` (visibility: all repositories), so consumer repos can access it during `library-dependency-rollout` runs.\n\n## Prerequisites (already done)\n\n- New SSH signing key generated and set as `SSH_SIGNING_KEY` org secret on both `tazama-lf` and `frmscoe` orgs\n- Public key registered as a Signing Key on the `Justus-at-Tazama` GitHub account\n- Old repo-level `SSH_SIGNING_KEY` secret deleted from `tazama-lf/workflows`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security by implementing improved commit signing and authentication mechanisms for automated library dependency rollout and synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->