### PR TITLE
fix(ci): add --branch dev to shallow clone in library-dependency-rollout

### DIFF
--- a/.github/workflows/library-dependency-rollout.yml
+++ b/.github/workflows/library-dependency-rollout.yml
@@ -174,9 +174,11 @@ jobs:
             echo ""
             echo "=== Processing ${ORG}/${REPO} ==="
 
-            # Clone consumer repo
+            # Clone consumer repo (--branch dev so shallow clone fetches dev directly;
+            # without this, --depth=50 only fetches the default branch and git checkout dev fails)
             if ! git clone \
                 --depth=50 \
+                --branch dev \
                 "https://x-access-token:${ORG_TOKEN}@github.com/${ORG}/${REPO}.git" \
                 "${REPO_DIR}" 2>&1; then
               echo "::warning::Could not clone ${ORG}/${REPO}. Skipping."


### PR DESCRIPTION
## Problem

When `library-dependency-rollout.yml` clones a consumer repo with `--depth=50` and no `--branch` specified, Git only fetches the **default branch** (typically `main`). The subsequent `git checkout dev` then fails with:

```
error: pathspec 'dev' did not match any file(s) known to git
```

This happens even when the consumer repo has a `dev` branch, because the shallow clone never fetched it.

## Fix

Add `--branch dev` to the `git clone` command. This instructs Git to clone the `dev` branch directly, so the working tree is already on `dev` after cloning and the checkout succeeds.

## Affected repos

Any consumer repo whose default branch is not `dev` (e.g. `admin-service`) would hit this. The workflow already had a graceful skip path, but the rollout was silently not reaching those repos.

Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>