### PR TITLE
fix(ci): replace stale app_token ref with GH_TOKEN secret in consumer catalog fetch

### DIFF
--- a/.github/workflows/library-dependency-rollout.yml
+++ b/.github/workflows/library-dependency-rollout.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Fetch consumer catalog
         if: steps.check_rc.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           HTTP_STATUS=$(curl -s -o /tmp/catalog-response.json -w "%{http_code}" \
             -H "Authorization: token ${GH_TOKEN}" \


### PR DESCRIPTION
When the GitHub App token steps were removed from `library-dependency-rollout.yml`, the `Fetch consumer catalog` step was not updated - it still referenced `steps.app_token.outputs.token` which no longer exists.\n\nThis evaluates to an empty string, making the curl request unauthenticated. It has not caused visible failures because `tazama-lf/workflows` is a public repo (GitHub serves unauthenticated requests). However it would fail for any private repo and is incorrect regardless.\n\nFix: replace with `${{ secrets.GH_TOKEN }}`, consistent with the rest of the workflow.\n\nSigned-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>