### PR TITLE
fix(ci): add missing consumers to library-consumers.json

### DIFF
--- a/library-consumers.json
+++ b/library-consumers.json
@@ -32,6 +32,10 @@
       },
       {
         "org": "tazama-lf",
+        "repo": "frms-coe-startup-lib"
+      },
+      {
+        "org": "tazama-lf",
         "repo": "lumberjack"
       },
       {
@@ -41,6 +45,22 @@
       {
         "org": "tazama-lf",
         "repo": "relay-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "relay-service-integration-kafka"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "relay-service-integration-nats"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "relay-service-integration-rabbitmq"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "relay-service-integration-rest"
       },
       {
         "org": "tazama-lf",
@@ -57,6 +77,10 @@
       {
         "org": "tazama-lf",
         "repo": "rule-studio-example"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "tcs-lib"
       },
       {
         "org": "tazama-lf",
@@ -255,6 +279,10 @@
       {
         "org": "tazama-lf",
         "repo": "admin-service"
+      },
+      {
+        "org": "tazama-lf",
+        "repo": "auth-lib-provider-keycloak"
       },
       {
         "org": "tazama-lf",


### PR DESCRIPTION
Adds 7 missing consumer entries to `library-consumers.json` that were omitted when the file was originally populated.

## Changes

**`@tazama-lf/frms-coe-lib` - 6 missing consumers added:**
- `tazama-lf/frms-coe-startup-lib`
- `tazama-lf/relay-service-integration-kafka`
- `tazama-lf/relay-service-integration-nats`
- `tazama-lf/relay-service-integration-rabbitmq`
- `tazama-lf/relay-service-integration-rest`
- `tazama-lf/tcs-lib`

**`@tazama-lf/auth-lib` - 1 missing consumer added:**
- `tazama-lf/auth-lib-provider-keycloak`

These repos all depend on the respective libraries (confirmed via `package.json` on `dev`), so they must be included in the automated rollout when a new library version is published.
