### PR TITLE
fix(ci): split lint step so prettier does not fail check-style job

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -59,8 +59,11 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check linting
-        run: npm run lint
+      - name: Check linting (ESLint)
+        run: npm run lint:eslint
+      - name: Check linting (Prettier)
+        run: npm run lint:prettier
+        continue-on-error: true
 
   test:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'


### PR DESCRIPTION
## Summary

Fixes #112

The `check style` job ran `npm run lint`, which chains `lint:eslint && lint:prettier`. Prettier exits 1 on formatting differences, failing CI identically to a genuine ESLint error. This caused repos with pre-existing formatting drift to have a permanently broken `check style` job even with zero ESLint errors.

## Change

Split the single "Check linting" step into two steps:

- **Check linting (ESLint)** - runs `npm run lint:eslint`. Fails the job on genuine code errors.
- **Check linting (Prettier)** - runs `npm run lint:prettier` with `continue-on-error: true`. Reports formatting issues in the step output without blocking the job.

ESLint errors still gate merges. Prettier formatting drift is visible but non-blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI linting workflow to run ESLint and Prettier checks separately, allowing Prettier validation to continue without blocking the overall linting process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/workflows/pull/113)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->