### PR TITLE
fix(ci): expose GH_TOKEN on npm ci steps in node-ci.yml

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run build
         run: npm run build
 
@@ -59,6 +60,7 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check linting (ESLint)
         run: npm run lint:eslint
       - name: Check linting (Prettier)
@@ -83,5 +85,6 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Problem

Repos whose `.npmrc` uses `${GH_TOKEN}` for GitHub Packages authentication were getting 401 Unauthorized errors during `npm ci` in CI, but only when the npm cache was cold (i.e. the lockfile had changed).

Root cause: `actions/setup-node` writes `NODE_AUTH_TOKEN` into `~/.npmrc`, but the project-level `.npmrc` (which uses `${GH_TOKEN}`) takes precedence. Since `GH_TOKEN` was never set as an env var in the workflow, npm resolved it to empty and the request was unauthenticated.

This only surfaced in repos that actually download `@tazama-lf`-scoped packages (i.e. have them as dependencies). Repos like `frms-coe-lib` that have no such dependencies were unaffected because `npm ci` never contacted GitHub Packages.

## Fix

Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` alongside `NODE_AUTH_TOKEN` on all three `npm ci` steps (build, lint, test jobs). Both variables are now set, so repos using either convention authenticate correctly.

## Impact

- Fixes 401 auth failures in any repo with `@tazama-lf`-scoped dependencies
- No change to repos that don't use GitHub Packages
- `NODE_AUTH_TOKEN` is kept so existing repos relying on it continue to work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use GitHub token authentication during the dependency installation step for build, lint, and test jobs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/workflows/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->