### PR TITLE
ci: refactor codacy scan to reusable workflow with docker tools disabled

### DIFF
--- a/.github/workflows/codacy-ci.yml
+++ b/.github/workflows/codacy-ci.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable Codacy Security Scan workflow.
+# Called by consumer repos via a thin stub (codacy.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Codacy Security Scan (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  codacy-security-scan:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Codacy Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          verbose: true
+          output: results.sarif
+          format: sarif
+          # Adjust severity of non-security issues
+          gh-code-scanning-compat: true
+          # Force 0 exit code to allow SARIF file generation
+          # This will handover control about PR rejection to the GitHub side
+          max-allowed-issues: 2147483647
+          # Disable dockerized tools (e.g. Checkov) - not applicable to TypeScript/Node.js repos.
+          # ESLint and Semgrep run natively and are controlled via .codacy.yml.
+          run-docker-tools: 'false'
+
+      # Codacy outputs one SARIF run per engine. The CodeQL upload-sarif action rejects
+      # files with multiple runs sharing the same category (enforced since 2025-07-21).
+      # Merge all runs into one before uploading.
+      - name: Merge SARIF runs into single run
+        run: |
+          jq '
+            if (.runs | length) > 1 then
+              .runs = [{
+                "tool": {
+                  "driver": {
+                    "name": "Codacy",
+                    "informationUri": "https://www.codacy.com",
+                    "rules": ([.runs[].tool.driver.rules[]?] | unique_by(.id))
+                  }
+                },
+                "results": [.runs[].results[]?]
+              }]
+            else . end
+          ' results.sarif > merged.sarif && mv merged.sarif results.sarif
+
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+        with:
+          sarif_file: results.sarif
+          category: codacy

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,17 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow checks out code, performs a Codacy security scan
-# and integrates the results with the
-# GitHub Advanced Security code scanning feature.  For more information on
-# the Codacy security scan action usage and parameters, see
-# https://github.com/codacy/codacy-analysis-cli-action.
-# For more information on Codacy Analysis CLI in general, see
-# https://github.com/codacy/codacy-analysis-cli.
+# Caller stub: delegates all Codacy scan logic to the centralised reusable workflow.
+# Logic changes belong in codacy-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -21,65 +11,16 @@ on:
   push:
     branches: [ "dev", "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "dev", "main" ]
   schedule:
     - cron: '17 0 * * 4'
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 jobs:
   codacy-security-scan:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Codacy Security Scan
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
-        with:
-          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
-          # You can also omit the token and run the tools that support default configurations
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          verbose: true
-          output: results.sarif
-          format: sarif
-          # Adjust severity of non-security issues
-          gh-code-scanning-compat: true
-          # Force 0 exit code to allow SARIF file generation
-          # This will handover control about PR rejection to the GitHub side
-          max-allowed-issues: 2147483647
-
-      # Codacy outputs one SARIF run per engine. The CodeQL upload-sarif action rejects
-      # files with multiple runs sharing the same category (enforced since 2025-07-21).
-      # Merge all runs into one before uploading.
-      - name: Merge SARIF runs into single run
-        run: |
-          jq '
-            if (.runs | length) > 1 then
-              .runs = [{
-                "tool": {
-                  "driver": {
-                    "name": "Codacy",
-                    "informationUri": "https://www.codacy.com",
-                    "rules": ([.runs[].tool.driver.rules[]?] | unique_by(.id))
-                  }
-                },
-                "results": [.runs[].results[]?]
-              }]
-            else . end
-          ' results.sarif > merged.sarif && mv merged.sarif results.sarif
-
-      # Upload the SARIF file generated in the previous step
-      - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
-        with:
-          sarif_file: results.sarif
-          category: codacy
+    uses: tazama-lf/workflows/.github/workflows/codacy-ci.yml@dev
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following checks run automatically on pull requests across all repo classes.
 | `conventional-commits.yml` | PR title is validated against the [Conventional Commits](https://www.conventionalcommits.org/) specification |
 | `dco-check.yml` | All commits carry a DCO `Signed-off-by` trailer - ⚠️ [known issue #37](https://github.com/tazama-lf/workflows/issues/37) |
 | `gpg-verify.yml` | All commits are GPG-signed |
-| `codacy.yml` | Static analysis via Codacy CLI; SARIF runs merged by `jq` before upload - ⚠️ [known issue #38](https://github.com/tazama-lf/workflows/issues/38) |
+| `codacy.yml` | Caller stub; delegates to `codacy-ci.yml` - static analysis via Codacy CLI (ESLint, Semgrep); Docker tools disabled; SARIF runs merged by `jq` before upload - ⚠️ [known issue #38](https://github.com/tazama-lf/workflows/issues/38) |
 | `codeql.yml` | GitHub CodeQL SAST security scan |
 | `njsscan.yml` | Node.js-specific security scan (semgrep rules) |
 | `dependency-review.yml` | Flags new dependencies with known CVEs or licence restrictions |

--- a/workflow-docs/codacy-ci.md
+++ b/workflow-docs/codacy-ci.md
@@ -1,0 +1,77 @@
+# `codacy-ci.yml`
+
+## Purpose
+
+Reusable Codacy Security Scan workflow. Contains all scan logic for Tazama consumer repos. Called by the [`codacy.yml`](codacy.md) caller stub which is synced to all consumer repos.
+
+This file is **not synced** to consumer repos - it stays in `tazama-lf/workflows` and is referenced by the stub at runtime via `uses: tazama-lf/workflows/.github/workflows/codacy-ci.yml@dev`.
+
+Dockerized tools (e.g. Checkov) are disabled via `run-docker-tools: 'false'`. They are not applicable to TypeScript/Node.js repos and were previously triggering spurious Checkov runs despite `.codacy.yml` exclusions. ESLint and Semgrep continue to run natively and are controlled via `.codacy.yml`. See [#115](https://github.com/tazama-lf/workflows/issues/115).
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `workflow_call` | Called by `codacy.yml` stub in consumer repos |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Typical duration | ~2-3 min |
+| Concurrency | none |
+| Permissions | `contents: read`, `security-events: write`, `actions: read` |
+
+---
+
+## Jobs
+
+### `codacy-security-scan` - Codacy Security Scan
+
+**Condition:** `github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'`
+
+**Steps:**
+
+1. `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4) - checks out source
+2. `codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` (v4.4.7) - runs Codacy CLI with `run-docker-tools: 'false'`; outputs `results.sarif`; `max-allowed-issues: 2147483647` defers PR rejection to GitHub
+3. Merge SARIF runs - inline `jq` step that merges all SARIF runs from `results.sarif` into a single run before upload; required because the Codacy CLI emits one run per engine and `upload-sarif` rejects uploads with more than one run per category (enforced from 2025-07-21) - fixes [#98](https://github.com/tazama-lf/workflows/issues/98)
+4. `github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699` (v3) - uploads the merged `results.sarif` to GitHub code scanning with `category: codacy`
+
+---
+
+## Required Secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `CODACY_PROJECT_TOKEN` | repo | Authenticate with the Codacy project |
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|-------------|
+| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4 |
+| `codacy/codacy-analysis-cli-action` | `562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` | v4.4.7 |
+| `github/codeql-action/upload-sarif` | `5c8a8a642e79153f5d047b10ec1cba1d1cc65699` | v3 |
+
+---
+
+## Known Limitations / Notes
+
+- The Codacy CLI emits one SARIF run per engine. A jq step merges all runs into a single run before upload to satisfy the `upload-sarif` single-run-per-category requirement (enforced from 2025-07-21). See [#98](https://github.com/tazama-lf/workflows/issues/98).
+- `dependabot[bot]` actors are excluded via the job condition.
+- When `project-token` is supplied, the Codacy cloud platform config takes precedence over the local `.codacy.yml` engine settings. The `run-docker-tools: 'false'` input bypasses this for all Docker-pulled tools regardless of cloud config.
+
+---
+
+## Repository Overrides
+
+| Repository | Reason |
+|-----------|--------|
+| _(none)_ | _(logic centralised here; all repos reference via stub)_ |

--- a/workflow-docs/codacy.md
+++ b/workflow-docs/codacy.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Performs a Codacy security scan of the codebase and uploads results in SARIF format to GitHub Advanced Security (code scanning dashboard).
+Caller stub that delegates Codacy Security Scan logic to the centralised reusable workflow [`codacy-ci.yml`](codacy-ci.md). Contains only the push/PR/schedule triggers and a single `uses:` reference - no logic lives here. This file is synced to all consumer repos unchanged.
 
 ---
 
@@ -18,33 +18,38 @@ Performs a Codacy security scan of the codebase and uploads results in SARIF for
 
 ## Execution Context
 
-| Property | Value |
-|----------|-------|
-| Runner | `ubuntu-latest` |
-| Typical duration | ~2–3 min |
-| Concurrency | none |
-| Permissions | `contents: read`, `security-events: write`, `actions: read` |
+All execution context is defined in [`codacy-ci.yml`](codacy-ci.md). This stub adds no jobs, steps, or environment variables of its own.
 
 ---
 
 ## Jobs
 
-### `codacy-security-scan` - Codacy Security Scan
+### `codacy-security-scan`
 
-**Steps:**
+Delegates entirely to the reusable workflow:
 
-1. `actions/checkout@v4` - checks out source
-2. `codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` - runs Codacy CLI; outputs `results.sarif`; `max-allowed-issues: 2147483647` defers PR rejection to GitHub
-3. Merge SARIF runs - inline `jq` step that merges all SARIF runs from `results.sarif` into a single run before upload; required because the Codacy CLI emits one run per engine and `upload-sarif` rejects uploads with more than one run per category (enforced from 2025-07-21) - fixes [#98](https://github.com/tazama-lf/workflows/issues/98)
-4. `github/codeql-action/upload-sarif@v3` - uploads the merged `results.sarif` to GitHub code scanning
+```yaml
+uses: tazama-lf/workflows/.github/workflows/codacy-ci.yml@dev
+secrets: inherit
+```
+
+See [`codacy-ci.yml` documentation](codacy-ci.md) for the full job breakdown.
 
 ---
 
 ## Required Secrets
 
-| Secret | Scope | Purpose |
-|--------|-------|-------|
-| `CODACY_PROJECT_TOKEN` | repo | Authenticate with the Codacy project |
+All secrets are passed through via `secrets: inherit`. See [`codacy-ci.yml`](codacy-ci.md) for the list.
+
+---
+
+## Permissions
+
+| Scope | Level |
+|-------|-------|
+| `contents` | `read` |
+| `security-events` | `write` |
+| `actions` | `read` |
 
 ---
 
@@ -54,27 +59,4 @@ Performs a Codacy security scan of the codebase and uploads results in SARIF for
 |-------|----------|
 | All `REPOS` | Receives this file |
 
----
-
-## Dependencies (pinned actions)
-
-| Action | Pinned SHA | Semver alias |
-|--------|-----------|----------|
-| `codacy/codacy-analysis-cli-action` | `562ee3e92b8e92df8b67e0a5ff8aa8e261919c08` | v4.4.7 |
-| `github/codeql-action/upload-sarif` | tag ref `v3` | - |
-
----
-
-## Known Limitations / Notes
-
-- Codacy CLI v4.4.7 is the latest available release. A known Java charset decoder bug (`MalformedInputException: Input length = 2`) causes the workflow to crash when checkov outputs code snippets from modified multi-line YAML files. Mitigated in this repo by `.checkov.yaml` (skips `github_actions` framework). Individual synced repos that modify complex YAML workflows may need the same `.checkov.yaml`.
-- The Codacy CLI emits one SARIF run per engine. A jq step merges all runs into a single run before upload to satisfy the `upload-sarif` single-run-per-category requirement (enforced from 2025-07-21). See [#98](https://github.com/tazama-lf/workflows/issues/98).
-- `dependabot[bot]` actors are excluded.
-
----
-
-## Repository Overrides
-
-| Repository | Reason |
-|-----------|--------|
-| _(none)_ | _(all synced repos use the canonical version)_ |
+Because the stub is static (it always points to `@dev`), subsequent syncs will skip repos where the file is already up to date.


### PR DESCRIPTION
## Summary

Refactors the Codacy Security Scan workflow to follow the stub/reusable pattern used by `node.js.yml`/`node-ci.yml`, and fixes Checkov running on every PR despite being excluded in `.codacy.yml`.

Closes #115

## Root cause

When `project-token` is supplied to `codacy-analysis-cli-action`, the Codacy cloud platform config takes precedence over the local `.codacy.yml` engine settings. The platform still had Checkov enabled, so it ran on every PR regardless of local exclusions.

The `tool` input only supports a single tool name, so it cannot be used to allowlist multiple tools. The `run-docker-tools: 'false'` input is the correct fix - it disables all Docker-pulled tools (Checkov etc.) entirely, bypassing the cloud config. ESLint and Semgrep run natively and are unaffected.

## Changes

### `codacy-ci.yml` (new)
Reusable workflow (`workflow_call` trigger) containing all Codacy scan logic:
- `run-docker-tools: 'false'` - disables Checkov and other Docker-pulled tools not applicable to TypeScript/Node.js repos
- ESLint and Semgrep continue to run natively, controlled via `.codacy.yml`
- SARIF merge step retained (fixes #98)
- `dependabot[bot]` exclusion retained

### `codacy.yml` (updated)
Replaced with a thin caller stub following the same pattern as `node.js.yml`. No logic - just the push/PR/schedule triggers and a `uses: tazama-lf/workflows/.github/workflows/codacy-ci.yml@dev` reference. This is the file synced to all consumer repos.

### Docs
- `workflow-docs/codacy.md` - rewritten as stub doc
- `workflow-docs/codacy-ci.md` - new doc for the reusable workflow
- `README.md` - updated Standard PR Check Suite table entry

## Testing

After merge and sync, the Codacy scan on consumer repos should complete without running Checkov. The `results.sarif` upload to GitHub Advanced Security should continue working as before.
