### PR TITLE
fix: delete stale lock file before npm install in package-rule-rc

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -146,10 +146,28 @@ jobs:
             exit 1
           fi
 
-      - name: Install dependencies
+      - name: Regenerate package-lock.json for rule ${{ inputs.rule_number }}
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
-          npm install
+          # Delete the stale lock file so npm generates a fresh one from the
+          # modified package.json (which now references the correct rule module).
+          # Without this, `npm ci` in the Docker build follows the old lock file
+          # and installs the wrong rule module regardless of package.json.
+          rm -f package-lock.json
+          npm install --package-lock-only
+          # Verify the lock file was regenerated with the correct rule module
+          RULE_NUM="${{ inputs.rule_number }}"
+          RULE_ORG="${{ inputs.rule_org }}"
+          case "$RULE_ORG" in
+            frmscoe)   EXPECTED_SCOPE="@frmscoe" ;;
+            tazama-lf) EXPECTED_SCOPE="@tazama-lf" ;;
+          esac
+          if ! grep -q "\"name\": \"${EXPECTED_SCOPE}/rule-${RULE_NUM}\"" package-lock.json; then
+            echo "❌ package-lock.json was not updated to reference ${EXPECTED_SCOPE}/rule-${RULE_NUM}"
+            grep '"name": "@' package-lock.json | grep rule | head -5 || true
+            exit 1
+          fi
+          echo "✅ package-lock.json correctly references ${EXPECTED_SCOPE}/rule-${RULE_NUM}"
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 


### PR DESCRIPTION
## Problem

The `package-rule-rc.yml` reusable workflow builds a rule-executer Docker image with a specific rule module installed. It does this by:

1. Cloning `rule-executer` (dev branch)
2. Using `sed` to update the `rule` dependency in `package.json` (e.g. `rule-901` -> `rule-902`)
3. Running `npm install` to update dependencies
4. Building the Docker image with `npm ci`

**The bug:** `sed` only updates `package.json`. The cloned `package-lock.json` still references the old rule module (`rule-901`). When Docker runs `npm ci`, it follows the lock file strictly - it installs `rule-901` regardless of what `package.json` says.

This was confirmed in production: `tazamaorg/rule-902:rc` was found to have `@tazama-lf/rule-901` installed inside the container, which triggered the identity check in rule-executer and caused the container to fail on startup.

## Root cause

`npm ci` is by design strictly deterministic - it ignores `package.json` and installs exactly what the lock file specifies. The previous `npm install` step was intended to update the lock file, but was not doing so reliably (possibly due to auth issues fetching the new module's metadata from GitHub Packages).

## Fix

Delete `package-lock.json` before running `npm install`, and switch to `--package-lock-only`:

- `rm -f package-lock.json` - removes the stale lock file so npm generates a fresh one
- `npm install --package-lock-only` - regenerates the lock file from the modified `package.json` without installing `node_modules` locally (Docker handles the actual install via `npm ci`)
- Post-install grep validates the lock file was correctly updated before the Docker build proceeds, so mismatches are caught early with a clear error

## Testing

Trigger the `package-rule-rc.yml` workflow for any rule (e.g. rule-902 via `workflow_dispatch` or a push to its dev branch) and verify the built image contains the correct rule module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow to regenerate package lock files after dependency modifications and validate package references, ensuring consistency and integrity in the build process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/workflows/pull/118)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->