### PR TITLE
ci: add --ignore-scripts to npm install in package-rule-rc

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -154,7 +154,7 @@ jobs:
           # Without this, `npm ci` in the Docker build follows the old lock file
           # and installs the wrong rule module regardless of package.json.
           rm -f package-lock.json
-          npm install --package-lock-only
+          npm install --package-lock-only --ignore-scripts
           # Verify the lock file was regenerated with the correct rule module
           RULE_NUM="${{ inputs.rule_number }}"
           RULE_ORG="${{ inputs.rule_org }}"


### PR DESCRIPTION
## Problem

The previous fix (#118) deleted the stale `package-lock.json` and used `npm install --package-lock-only` to regenerate it. However, `rule-executer` has a `prepare` lifecycle script that runs `husky`. Since `node_modules` is not installed at that point, `husky` is not found and npm exits with code 127.

## Fix

Add `--ignore-scripts` to skip all lifecycle hooks during lock file regeneration. Only the lock file needs to be written - no scripts need to run.

```diff
-npm install --package-lock-only
+npm install --package-lock-only --ignore-scripts
```
