### PR TITLE
docs: document lock file incident and fix in package-rule-rc.md

### DIFF
--- a/workflow-docs/package-rule-rc.md
+++ b/workflow-docs/package-rule-rc.md
@@ -44,12 +44,12 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 **Steps:**
 
 1. `actions/checkout@v4` - checks out rule repo source
-2. `actions/setup-node@v4` - Node 20
+2. `actions/setup-node@v4` - Node 22
 3. `Read rule version from package.json` - reads `version`; fails if version is NOT a prerelease (`-` suffix required - guards against RC build running on a stable version)
 4. `Clone Rule Executer repository (dev branch)` - clones `tazama-lf/rule-executer@dev`
 5. `Prepare rule-executer-<N>` - copies cloned directory
-6. `Modify package.json and Dockerfile for rule <N>` - uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded
-7. `Install dependencies` - `npm install` in the patched directory (uses `npm install` rather than `npm ci` because the preceding `sed` step modifies `package.json`, invalidating the lockfile)
+6. `Modify package.json and Dockerfile for rule <N>` - uses a `case` statement on `rule_org` (`frmscoe` → `@frmscoe` scope + `npm:@frmscoe/rule-*`; `tazama-lf` → `@tazama-lf` scope + `npm:@tazama-lf/rule-*`; any other value → `exit 1`) to patch the rule dependency, `ENV RULE_NAME`, `ENV APM_SERVICE_NAME`; validates each substitution succeeded with `grep` + `exit 1`
+7. `Regenerate package-lock.json for rule <N>` - deletes the stale lock file, runs `npm install --package-lock-only --ignore-scripts` to regenerate it from the modified `package.json`, then validates the lock file references the correct rule module (see [Lock file design note](#lock-file-design-note) below)
 8. `Build and push RC Docker image` - builds once; tags with `VERSION` and `:rc`; pushes both
 9. `Send Slack notification` - posts to `SLACK_WEBHOOK_URL`
 
@@ -89,6 +89,34 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 - `dependabot[bot]` actors are excluded.
 - Rule repo caller stubs also trigger on `repository_dispatch: types: [rule-executer-update]`, enabling rule images to be rebuilt when `rule-executer` itself changes without needing a new commit in the rule repo.
 - The `:rc` tag is a floating pointer overwritten on every push to `dev`. Use the versioned tag (e.g. `1.0.0-rc.2`) for reproducible deployments.
+
+---
+
+## Lock file design note
+
+### Why the lock file must be regenerated
+
+The Docker build runs `npm ci`, which is strictly deterministic: it installs exactly what `package-lock.json` specifies and ignores `package.json` entirely. The `sed` step in this workflow updates `package.json` to reference the correct rule module (e.g. `@tazama-lf/rule-902`), but the cloned lock file still references whichever rule was in `rule-executer` at clone time (e.g. `@tazama-lf/rule-901`). Without regenerating the lock file, `npm ci` installs the wrong rule module regardless of what `package.json` says.
+
+### Why `--package-lock-only --ignore-scripts`
+
+- `--package-lock-only` - writes only the lock file; does not create `node_modules` locally. The actual install is done inside the Docker build via `npm ci`, so installing locally is wasted work.
+- `--ignore-scripts` - `rule-executer` has a `prepare` lifecycle script that runs `husky`. Since `node_modules` is absent, `husky` is not found and npm exits with code 127. `--ignore-scripts` skips all lifecycle hooks.
+
+### Post-generate validation
+
+After regeneration, the step greps the lock file for `"name": "${EXPECTED_SCOPE}/rule-${RULE_NUM}"`. If the entry is missing (e.g. the module was not published yet, or auth to the npm registry failed silently), the step fails with a clear error before the Docker build starts. Without this check, a silent failure would cause `npm ci` to error inside Docker with a much less obvious message.
+
+### Incident (May 2026)
+
+The original workflow used a plain `npm install` without deleting the lock file first. Because `npm ci` is deterministic on the lock file, a Docker image for `rule-902` was built and pushed containing the `rule-901` module. The mismatch was caught at runtime by the identity check added to `rule-executer` (PR #408), which compares `RULE_ID` exported by the loaded module against the `RULE_NAME` environment variable and refuses to start if they differ. The container logged the identity mismatch and exited on startup.
+
+**Root cause chain:**
+1. `package-rule-rc.yml` ran `sed` on `package.json` only - the lock file was not updated.
+2. Docker's `npm ci` followed the lock file and installed `rule-901` into the `rule-902` image.
+3. `rule-executer` started, loaded the `rule` module alias, read `RULE_ID = '901'`, compared it to `RULE_NAME = '902'`, and exited with an identity mismatch error.
+
+**Fix applied:** PRs #118 and #119 in `tazama-lf/workflows`, PR #89 in `frmscoe/workflows`.
 
 ---
 


### PR DESCRIPTION
Updates `workflow-docs/package-rule-rc.md` to document the lock file design decisions and the May 2026 rule-902 identity mismatch incident.

## What is added

### Lock file design note (new section)

- **Why the lock file must be regenerated** - explains that `npm ci` is deterministic on the lock file and ignores `package.json`, so `sed` alone is insufficient
- **Why `--package-lock-only --ignore-scripts`** - explains both flags: no local install needed (Docker does it), and `husky prepare` requires `node_modules` which are absent
- **Post-generate validation** - explains the grep check and why it catches failures that would otherwise surface as obscure `npm ci` errors inside Docker
- **Incident (May 2026)** - records the root cause chain: sed updated package.json only -> npm ci followed stale lock file -> wrong rule module installed -> identity check caught it at startup -> container refused to start; references fix PRs #118, #119, #89

### Updated step descriptions

- Step 7: updated from "Install dependencies / npm install" to reflect current implementation
- Node version: corrected from 20 to 22
