### PR TITLE
fix(ci): use raw URLs in sync-workflows PR summary

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -310,9 +310,8 @@ jobs:
               echo "### New PRs created (${#CREATED_PRS[@]})"
               echo ""
               for entry in "${CREATED_PRS[@]}"; do
-                repo_name="${entry%% *}"
                 pr_url="${entry#* }"
-                echo "- [$repo_name]($pr_url)"
+                echo "- $pr_url"
               done
               echo ""
             fi
@@ -320,9 +319,8 @@ jobs:
               echo "### Existing PRs updated (${#EXISTING_PRS[@]})"
               echo ""
               for entry in "${EXISTING_PRS[@]}"; do
-                repo_name="${entry%% *}"
                 pr_url="${entry#* }"
-                echo "- [$repo_name]($pr_url)"
+                echo "- $pr_url"
               done
               echo ""
             fi


### PR DESCRIPTION
Replace markdown hyperlinks (`[org/repo](url)`) with plain URLs in the sync-workflows job summary so they can be copied directly from the Actions summary page.

Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>
