### PR TITLE
fix(ci): use explicit markdown links in sync-workflows PR summary

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -311,7 +311,7 @@ jobs:
               echo ""
               for entry in "${CREATED_PRS[@]}"; do
                 pr_url="${entry#* }"
-                echo "- $pr_url"
+                echo "- [$pr_url]($pr_url)"
               done
               echo ""
             fi
@@ -320,7 +320,7 @@ jobs:
               echo ""
               for entry in "${EXISTING_PRS[@]}"; do
                 pr_url="${entry#* }"
-                echo "- $pr_url"
+                echo "- [$pr_url]($pr_url)"
               done
               echo ""
             fi


### PR DESCRIPTION
GitHub auto-shortens bare URLs in step summaries to `org/repo#number` format. Using `[url](url)` sets explicit link text that is preserved as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * GitHub Actions job summaries now display pull request URLs as clickable Markdown links instead of plain text for both newly created and existing PR sections, improving navigation and user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/workflows/pull/125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->