### PR TITLE
feat(ci): sync workflows to both dev and main in consumer repos

### DIFF
--- a/.github/workflows/branch-target-check-ci.yml
+++ b/.github/workflows/branch-target-check-ci.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           SOURCE: ${{ github.head_ref }}
         run: |
-          if [[ "$SOURCE" == "dev" || "$SOURCE" == release/v[0-9]* ]]; then
+          if [[ "$SOURCE" == "dev" || "$SOURCE" == release/v[0-9]* || "$SOURCE" == "sync-workflows-update-main" ]]; then
             echo "✅ Source branch '$SOURCE' is a valid base for a PR to main."
           else
             echo "❌ PRs to main must come from 'dev' or a 'release/v<N>.*' branch (e.g. release/v1.2)."
@@ -33,6 +33,7 @@ jobs:
             echo "   If you are working on a feature or fix, please retarget this PR to 'dev':"
             echo "     gh pr edit --base dev"
             echo ""
-            echo "   Only 'dev' → main (via release-train.yml) and 'release/v<N>.*' → main merges are permitted."
+            echo "   Only 'dev' → main (via release-train.yml), 'release/v<N>.*' → main, and"
+            echo "   'sync-workflows-update-main' → main (automated workflow sync) merges are permitted."
             exit 1
           fi

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -155,6 +155,8 @@ jobs:
           # Accumulate PR results for the job summary
           CREATED_PRS=()
           EXISTING_PRS=()
+          CREATED_MAIN_PRS=()
+          EXISTING_MAIN_PRS=()
           NO_CHANGE_REPOS=()
 
           # Build the temp-workflows bundle once, outside the repo loop
@@ -299,6 +301,90 @@ jobs:
               fi
             fi
 
+            # --- Main branch sync ---
+            # Syncs the same workflow files to main so that scheduled workflows (scorecard, codeql,
+            # njsscan, etc.) always find current stub files on the default (release) branch.
+            # GitHub's scheduler always reads scheduled workflows from the repository's default branch.
+            # RESERVED: sync-workflows-update-main is managed by this workflow - do not use it for regular development contributions.
+            if git ls-remote --heads origin main | grep -q main; then
+              if git ls-remote --heads origin sync-workflows-update-main | grep -q sync-workflows-update-main; then
+                git push origin --delete sync-workflows-update-main || true
+              fi
+              git fetch origin main
+              git checkout -B main origin/main
+              git checkout -b sync-workflows-update-main
+              mkdir -p .github/workflows
+              for file in ../temp-workflows/*; do
+                filename=$(basename "$file")
+                if in_list "$repo" "$SPECIFIC_REPOS" && [[ " ${SPECIFIC_FILES} " =~ " ${filename} " ]]; then
+                  continue
+                fi
+                if [[ "${filename}" == "publish.yml" || "${filename}" == "version-check.yml" || "${filename}" == "release-train.yml" || "${filename}" == "library-dependency-rollout.yml" ]] && ! in_list "$repo" "$PUBLISH_REPOS"; then
+                  continue
+                fi
+                if in_list "$repo" "$RULE_REPOS" && [[ "${filename}" == package-rule*.yml ]]; then
+                  continue
+                fi
+                if [[ "${filename}" == "scorecard.yml" ]] && in_list "$repo" "$PUBLISH_REPOS"; then
+                  continue
+                fi
+                cp -r "$file" ".github/workflows/"
+              done
+              if in_list "$repo" "$RULE_REPOS"; then
+                RULE_NUM="${repo#rule-}"
+                printf '%s\n' \
+                  '# SPDX-License-Identifier: Apache-2.0' \
+                  '# This file is managed centrally - do not edit manually.' \
+                  '# To change build behaviour, update the reusable workflow in tazama-lf/workflows.' \
+                  'on:' \
+                  '  push:' \
+                  '    branches: [dev]' \
+                  '  repository_dispatch:' \
+                  '    types: [rule-executer-update]' \
+                  '  workflow_dispatch:' \
+                  'jobs:' \
+                  '  build:' \
+                  "    uses: tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev" \
+                  '    with:' \
+                  "      rule_number: \"${RULE_NUM}\"" \
+                  '      rule_org: "tazama-lf"' \
+                  '    secrets: inherit' \
+                  > ".github/workflows/package-rule-rc.yml"
+                printf '%s\n' \
+                  '# SPDX-License-Identifier: Apache-2.0' \
+                  '# This file is managed centrally - do not edit manually.' \
+                  '# To change build behaviour, update the reusable workflow in tazama-lf/workflows.' \
+                  'on:' \
+                  '  push:' \
+                  '    branches: [main]' \
+                  '  workflow_dispatch:' \
+                  'jobs:' \
+                  '  build:' \
+                  "    uses: tazama-lf/workflows/.github/workflows/package-rule.yml@main" \
+                  '    with:' \
+                  "      rule_number: \"${RULE_NUM}\"" \
+                  '      rule_org: "tazama-lf"' \
+                  '    secrets: inherit' \
+                  > ".github/workflows/package-rule.yml"
+              fi
+              cp "${WORKFLOWS_ROOT}/config-templates/.codacy.yml" ".codacy.yml"
+              rm -f .github/workflows/dco-check.yaml
+              git add -A .github/workflows/ .codacy.yml
+              git commit -m "ci: sync workflows from central-workflows [skip ci]" -m "${SIGNED_OFF_BY}" || echo "No changes to commit"
+              git push origin sync-workflows-update-main || git push origin sync-workflows-update-main --force
+
+              MAIN_PR_URL=$(gh pr create --title "ci: sync workflows from central-workflows [skip ci]" --body "$PR_BODY" --base main --head sync-workflows-update-main $REVIEWERS_ARGS 2>/dev/null)
+              if [ -n "$MAIN_PR_URL" ]; then
+                CREATED_MAIN_PRS+=("$ORG/$repo $MAIN_PR_URL")
+              else
+                gh pr edit sync-workflows-update-main --title "ci: sync workflows from central-workflows [skip ci]" --body "$PR_BODY" 2>/dev/null || true
+                EXISTING_MAIN_URL=$(gh pr view sync-workflows-update-main --repo "$ORG/$repo" --json url --jq '.url' 2>/dev/null || echo "")
+                if [ -n "$EXISTING_MAIN_URL" ]; then
+                  EXISTING_MAIN_PRS+=("$ORG/$repo $EXISTING_MAIN_URL")
+                fi
+              fi
+            fi
+
             cd ..
           done
 
@@ -306,8 +392,10 @@ jobs:
           {
             echo "## Sync Workflows — PR Summary"
             echo ""
+            echo "### PRs to dev"
+            echo ""
             if [ ${#CREATED_PRS[@]} -gt 0 ]; then
-              echo "### New PRs created (${#CREATED_PRS[@]})"
+              echo "#### New PRs created (${#CREATED_PRS[@]})"
               echo ""
               for entry in "${CREATED_PRS[@]}"; do
                 pr_url="${entry#* }"
@@ -316,7 +404,7 @@ jobs:
               echo ""
             fi
             if [ ${#EXISTING_PRS[@]} -gt 0 ]; then
-              echo "### Existing PRs updated (${#EXISTING_PRS[@]})"
+              echo "#### Existing PRs updated (${#EXISTING_PRS[@]})"
               echo ""
               for entry in "${EXISTING_PRS[@]}"; do
                 pr_url="${entry#* }"
@@ -325,6 +413,30 @@ jobs:
               echo ""
             fi
             if [ ${#CREATED_PRS[@]} -eq 0 ] && [ ${#EXISTING_PRS[@]} -eq 0 ]; then
-              echo "_No PRs were created or updated — all repos were already up to date._"
+              echo "_No dev PRs were created or updated — all repos were already up to date._"
+              echo ""
+            fi
+            echo "### PRs to main"
+            echo ""
+            if [ ${#CREATED_MAIN_PRS[@]} -gt 0 ]; then
+              echo "#### New PRs created (${#CREATED_MAIN_PRS[@]})"
+              echo ""
+              for entry in "${CREATED_MAIN_PRS[@]}"; do
+                pr_url="${entry#* }"
+                echo "- [$pr_url]($pr_url)"
+              done
+              echo ""
+            fi
+            if [ ${#EXISTING_MAIN_PRS[@]} -gt 0 ]; then
+              echo "#### Existing PRs updated (${#EXISTING_MAIN_PRS[@]})"
+              echo ""
+              for entry in "${EXISTING_MAIN_PRS[@]}"; do
+                pr_url="${entry#* }"
+                echo "- [$pr_url]($pr_url)"
+              done
+              echo ""
+            fi
+            if [ ${#CREATED_MAIN_PRS[@]} -eq 0 ] && [ ${#EXISTING_MAIN_PRS[@]} -eq 0 ]; then
+              echo "_No main PRs were created or updated._"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ Changes to this repo propagate to all 32 target repositories. This is the highes
 2. **DevOps** - opens pull request targeting `dev`.
 3. **AUTO** - standard PR check suite fires against this repo.
 4. **Reviewer - MANUAL** - reviews and merges the source PR to `dev` in this repo.
-5. **AUTO** - `sync-workflows.yml` fires on `push: dev`; opens `sync-workflows-update` PRs in all 32 target repos. The commit message and PR title both include `[skip ci]` so that squash-merging the sync PR suppresses all push-triggered workflows (CI, Docker builds) on the resulting commit in the target repo.
-6. **Reviewers in target repos - MANUAL** - review and merge `sync-workflows-update` PRs in each target repo. The `[skip ci]` tag prevents unnecessary workflow runs on merge.
+5. **AUTO** - `sync-workflows.yml` fires on `push: dev`; opens `sync-workflows-update` PRs (targeting `dev`) and `sync-workflows-update-main` PRs (targeting `main`) in all 32 target repos. Both PRs carry `[skip ci]` in the commit message and PR title so that squash-merging suppresses all push-triggered workflows (CI, Docker builds) on the resulting commit in the target repo.
+6. **Reviewers in target repos - MANUAL** - review and merge both the `sync-workflows-update → dev` and `sync-workflows-update-main → main` PRs in each target repo. Keeping `main` current ensures scheduled workflows (`scorecard.yml`, `codeql.yml`, `njsscan.yml`, etc.) always run against current stub files - GitHub's scheduler reads scheduled workflows from the default branch only.
 7. **DevOps - MANUAL** - applies the same changes to [`frmscoe/workflows`](https://github.com/frmscoe/workflows) via a separate PR (no automated mirror exists between the two workflow repos).
 8. **AUTO** - once merged to `dev` in `frmscoe/workflows`, its `sync-workflows.yml` fires on `push: dev` and distributes the changes to all 33 frmscoe rule repos.
 
@@ -311,11 +311,27 @@ Triggers shown are in the context of the **target repo** where each workflow is 
 |------|---------------------------|--------|
 | `config-templates/.codacy.yml` | `.codacy.yml` (repo root) | Standard Codacy engine allowlist for TypeScript/Node.js repos; enables ESLint and Semgrep only, suppressing false positives from Python/Java engines |
 
+**Workflow branch activation**
+
+Not all workflows are equally active on `dev` and `main`. The table below categorizes installed workflows by which branch they perform meaningful work on in a typical target repo. This is the primary reason the sync targets both branches.
+
+| Category | Workflows | Branch |
+|----------|-----------|--------|
+| **Scheduled security scans** - GitHub's scheduler reads from the default branch; stale `main` = broken or silently skipped scans | `scorecard.yml`, `codeql.yml` (schedule), `njsscan.yml` (schedule), `dockerfile-linter.yml` (schedule) | `main` required; also run on `dev` push |
+| **Release artifact builds** - fire on push to `main` only | `dockerhub-image-build.yml`, `publish.yml`, `sbom.yml` | `main` only |
+| **RC/dev artifact builds** - fire on push to `dev` only | `dockerhub-image-build-rc.yml`, `library-dependency-rollout.yml` | `dev` only |
+| **Push CI** - fire on push to both branches | `node.js.yml`, `dockerfile-linter.yml` (push trigger), `codeql.yml` (push trigger), `njsscan.yml` (push trigger) | Both |
+| **PR gate checks** - fire on pull request events only; physical branch location does not matter | `branch-target-check.yml`, `conventional-commits.yml`, `dco-check.yml`, `dependency-review.yml`, `encoding-check.yml`, `gpg-verify.yml`, `codacy.yml` | PR only |
+
 **Full `REPOS` list (32 repos):** `relay-service`, `auth-service`, `typology-processor`, `event-director`, `event-sidecar`, `lumberjack`, `nats-utilities`, `batch-ppa`, `admin-service`, `tms-service`, `transaction-aggregation-decisioning-processor`, `Full-Stack-Docker-Tazama`, `rule-executer`, `event-flow`, `frms-coe-lib`, `frms-coe-startup-lib`, `auth-lib`, `auth-lib-provider-keycloak`, `rule-901`, `rule-902`, `tcs-lib`, `relay-service-integration-nats`, `relay-service-integration-rest`, `relay-service-integration-kafka`, `relay-service-integration-rabbitmq`, `audit-lib`, `data-enrichment-service`, `event-monitoring-service`, `case-management-system`, `connection-studio`, `rule-studio`, `biar`.
 
 > **frmscoe rule repos are not in this list.** They are managed by [`frmscoe/workflows`](https://github.com/frmscoe/workflows), which syncs to 33 rule repos (`rule-001` through `rule-091`, active subset) via its own `sync-workflows.yml` triggered on `push: dev`.
 
 > ⚠️ **`sync-workflows-update` is a reserved branch name.** This branch is created and managed by `sync-workflows.yml` in every target repo. Do not use this name for regular development contributions - the sync workflow will delete it and recreate it fresh from `dev` on every run. If you have an open `sync-workflows-update` branch in a target repo, be aware it will be force-replaced the next time the workflow runs.
+
+> ⚠️ **`sync-workflows-update-main` is a reserved branch name.** This branch is created and managed by `sync-workflows.yml` alongside `sync-workflows-update`. It is always cut from `main` and its PR targets `main`. Do not use this name for regular development contributions - it will be force-replaced on every sync run.
+
+> **Why sync targets both `dev` and `main`:** GitHub's job scheduler always reads scheduled workflow definitions from the repository's default branch (`main`). If `main` is stale, scheduled scans like `scorecard.yml`, `codeql.yml`, and `njsscan.yml` run against outdated or missing stub files. Syncing to `main` ensures scheduled workflows always have current definitions regardless of what triggered the run.
 
 > ⚠️ **`dep/library-dependency-bump` is a reserved branch name.** This branch is created and managed by `library-dependency-rollout.yml` in every consumer repo. Do not use this name for regular development contributions. Multiple library bumps coalesce onto this branch - the workflow pushes new commits onto an existing branch rather than creating a new one.
 


### PR DESCRIPTION
## Summary

GitHub's job scheduler always reads scheduled workflow definitions from the repository's default branch (`main`). If `main` is stale, scheduled scans (`scorecard.yml`, `codeql.yml`, `njsscan.yml`) run against outdated or missing stub files.

## Changes

**`sync-workflows.yml`**
- Adds a second sync pass per consumer repo after the existing `dev` PR block
- Creates `sync-workflows-update-main` branch from `main`, copies the same workflow bundle (same per-file rules applied), commits with `[skip ci]`, and opens a PR to `main`
- Adds `CREATED_MAIN_PRS` and `EXISTING_MAIN_PRS` tracking arrays
- Job step summary now has `### PRs to dev` and `### PRs to main` subsections

**`branch-target-check-ci.yml`**
- Whitelists `sync-workflows-update-main` as a permitted source branch for PRs targeting `main` (alongside `dev` and `release/v*`)
- Since this is a reusable workflow called at runtime via `@dev` ref, the change takes effect immediately in all consumer repos with no sync required

**`README.md`**
- Section 8 updated to describe two PRs per consumer repo
- `sync-workflows-update-main` added as a reserved branch name warning
- Dual-branch sync rationale note added
- Workflow branch activation table added to Sync Distribution section

Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to synchronize configuration files to both `dev` and `main` branches, generating separate pull requests for each target
  * Updated documentation to reflect the dual-branch synchronization process and workflow distribution strategy

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/workflows/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->