### PR TITLE
fix(ci): guard codacy merge-SARIF step against missing results.sarif

### DIFF
--- a/.github/workflows/codacy-ci.yml
+++ b/.github/workflows/codacy-ci.yml
@@ -46,8 +46,14 @@ jobs:
       # Codacy outputs one SARIF run per engine. The CodeQL upload-sarif action rejects
       # files with multiple runs sharing the same category (enforced since 2025-07-21).
       # Merge all runs into one before uploading.
+      # Guard: when Codacy runs unauthenticated with no applicable findings it exits 0
+      # but does not write results.sarif. Create a minimal valid SARIF in that case so
+      # the upload step does not error on a missing or empty file.
       - name: Merge SARIF runs into single run
         run: |
+          if [ ! -s results.sarif ]; then
+            echo '{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"Codacy","rules":[]}},"results":[]}]}' > results.sarif
+          fi
           jq '
             if (.runs | length) > 1 then
               .runs = [{


### PR DESCRIPTION
## Problem

The scheduled Codacy workflow has been failing consistently in `event-flow` (and likely other repos) since the "Merge SARIF runs" step was added in #99.

**Root cause:** When Codacy runs unauthenticated (no `CODACY_PROJECT_TOKEN` set at org or repo level) and finds no applicable findings, the CLI exits 0 but does **not** write `results.sarif`. The subsequent `jq` command then fails with exit code 2 (file not found), causing the workflow to fail on every scheduled run.

## Fix

Add a `[ ! -s results.sarif ]` guard before the `jq` merge step. If the file is absent or empty, a minimal valid SARIF (one tool run, zero results) is synthesised so the upload step can proceed cleanly.

This handles:
- Missing `results.sarif` (file never created)
- Empty `results.sarif` (0 bytes)
- Normal case with one or multiple runs (existing logic unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI pipeline reliability by implementing a safeguard to handle missing or empty SARIF result files. The system now creates a minimal valid placeholder when needed, preventing subsequent merge and upload steps from failing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/workflows/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->