### PR TITLE
fix(ci): expose registry token at job level in node-ci.yml (#141)

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -25,6 +25,10 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     name: run build
+    # Token exposed at job level so nested installs (e.g. monorepo `cd backend && npm ci`) authenticate too.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Use Node.js 22
@@ -36,9 +40,6 @@ jobs:
           scope: ${{ env.NPM_SCOPE }}
       - name: Install dependencies
         run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run build
         run: npm run build
 
@@ -46,6 +47,10 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     name: check style
+    # Token exposed at job level so nested installs (e.g. monorepo `cd backend && npm ci`) authenticate too.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -58,9 +63,6 @@ jobs:
           scope: ${{ env.NPM_SCOPE }}
       - name: Install dependencies
         run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check linting (ESLint)
         run: npm run lint:eslint
       - name: Check linting (Prettier)
@@ -71,6 +73,10 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     name: check tests
+    # Token exposed at job level so nested installs (e.g. monorepo `cd backend && npm ci`) authenticate too.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -83,8 +89,5 @@ jobs:
           scope: ${{ env.NPM_SCOPE }}
       - name: Install dependencies
         run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## What

Promote `NODE_AUTH_TOKEN` / `GH_TOKEN` from the single `Install dependencies` step to **job-level** `env` in all three jobs (`build`, `lint`, `test`) of the reusable `node-ci.yml`, and remove the now-redundant per-step env.

Closes #141

## Why

Monorepo consumers (`tazama-lf/connection-studio`, `tazama-lf/rule-studio`) failed every `build` / `lint` / `test` run with:

```
npm error code E401
npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/@tazama-lf/tcs-lib/1.0.156/... - unauthenticated: User cannot be authenticated with the token provided.
```

The root `npm ci` succeeded, but these repos' scripts spawn **nested** installs from the build/test/lint steps:

```
build           -> npm run backend:build
backend:build   -> cd backend && npm ci && npm run build
backend:lint    -> cd backend && npm ci && npx prisma generate && npm run lint
frontend:lint   -> cd frontend && npm ci && npm run lint
```

The token was only set on the root `Install dependencies` step, so the nested `npm ci` ran with no `GH_TOKEN`. The committed `.npmrc` authenticates with `${GH_TOKEN}`, which then expanded to empty and npm sent an empty bearer token. GitHub Packages npm requires a valid token even for public packages (verified: anonymous -> 401, empty bearer -> 401, valid token -> 200), so the nested install always 401'd on `@tazama-lf/tcs-lib`.

Setting the token at the job level means every step - including nested installs - inherits it.

## Changes

- `build`, `lint`, `test` jobs: add job-level `env` with `NODE_AUTH_TOKEN` and `GH_TOKEN` set to `${{ secrets.GITHUB_TOKEN }}`.
- Remove the per-step `env` blocks on the `Install dependencies` steps (now redundant).

No change to permissions, action pins, or step logic.

## Verification

- Confirmed root cause from `connection-studio` run `27013461528` job log: root `npm ci` step had `GH_TOKEN: ***`; the `Run build` step (`cd backend && npm ci`) had no `GH_TOKEN` and `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX`, immediately followed by the E401.
- `node-ci.yml` validated as well-formed YAML.
- After merge, consumer repos should re-run their Node.js CI to confirm green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD authentication handling across build, lint, and test jobs for consistent token management
  * Refined lint workflow to focus exclusively on code quality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->