### PR TITLE
fix(ci): link Slack docker notifications to image repo and source PR (#132)

### DIFF
--- a/.github/workflows/dockerhub-image-build-dual-rc.yml
+++ b/.github/workflows/dockerhub-image-build-dual-rc.yml
@@ -77,12 +77,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-backend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_frontend_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -138,9 +151,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-frontend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/dockerhub-image-build-dual.yml
+++ b/.github/workflows/dockerhub-image-build-dual.yml
@@ -78,12 +78,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-backend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_frontend:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -139,9 +152,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-frontend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -73,9 +73,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -78,9 +78,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }} "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -200,6 +200,19 @@ jobs:
           docker rmi "${IMAGE}:${VERSION}" "${IMAGE}:rc"
           echo "RC image pushed: ${IMAGE}:${VERSION} and ${IMAGE}:rc"
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -227,8 +240,8 @@ jobs:
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*DockerHub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"
-                  }
+                    "text": "*DockerHub:*\n<https://hub.docker.com/r/tazamaorg/rule-${{ inputs.rule_number }}>"
+                  }${{ steps.src_pr.outputs.PR_FIELD }}
                 ]
               }
             ]

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -182,6 +182,19 @@ jobs:
           docker rmi "${IMAGE}:${VERSION}" "${IMAGE}:latest"
           echo "Stable image pushed: ${IMAGE}:${VERSION} and ${IMAGE}:latest"
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -209,8 +222,8 @@ jobs:
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*DockerHub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"
-                  }
+                    "text": "*DockerHub:*\n<https://hub.docker.com/r/tazamaorg/rule-${{ inputs.rule_number }}>"
+                  }${{ steps.src_pr.outputs.PR_FIELD }}
                 ]
               }
             ]


### PR DESCRIPTION
## Summary

Resolves #132 and adds a source-PR link to the Slack notifications sent after a Docker image publish.

Two changes to every Docker publish Slack notification:

1. **DockerHub link now points to the specific image repo** (the #132 fix). The link changes from the generic org listing `https://hub.docker.com/orgs/tazamaorg/repositories` to `https://hub.docker.com/r/tazamaorg/<image>`, which opens the tags, pull count, and description for the image that was just published.
2. **New "Source PR" field.** A `Resolve source PR` step derives the pull request that produced the merge commit via the `commits/{sha}/pulls` GitHub API and adds a `*Source PR:*` link to the message, so a recipient can trace the image back to the change that created it.

## How the PR link is resolved

```bash
PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty')
```

The `commits/{sha}/pulls` endpoint returns the PR containing the merge commit regardless of merge strategy (merge / squash / rebase), so this is far more robust than parsing `(#123)` out of the commit subject.

The field is **omitted** when no PR is associated with the commit (for example, `release: published` triggers, which are cut from a tag rather than a merge), keeping those messages clean. The step is `continue-on-error: true` and the API call is non-fatal, so a notification is never blocked by PR resolution.

## Affected workflows

| Workflow | Slack steps updated |
| --- | --- |
| `dockerhub-image-build.yml` | 1 |
| `dockerhub-image-build-rc.yml` | 1 |
| `dockerhub-image-build-dual.yml` | 2 (backend + frontend) |
| `dockerhub-image-build-dual-rc.yml` | 2 (backend + frontend) |
| `package-rule.yml` | 1 |
| `package-rule-rc.yml` | 1 |

## Notes

- Uses the automatic `GITHUB_TOKEN` (`github.token`); the `commits/{sha}/pulls` read is covered by the existing `contents: read` permission, so no new secret or permission is required.
- No change to the trigger conditions or to the build/push/attestation steps.
