### PR TITLE
fix(ci): use GH_TOKEN_LIB for DockerHub image build package auth

### DIFF
--- a/.github/workflows/dockerhub-image-build-dual-rc.yml
+++ b/.github/workflows/dockerhub-image-build-dual-rc.yml
@@ -68,7 +68,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
@@ -142,7 +142,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32

--- a/.github/workflows/dockerhub-image-build-dual.yml
+++ b/.github/workflows/dockerhub-image-build-dual.yml
@@ -69,7 +69,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
@@ -143,7 +143,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32

--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -64,7 +64,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -69,7 +69,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32


### PR DESCRIPTION
## What

Point the DockerHub image-build package-auth secret at `GH_TOKEN_LIB` instead of `GH_TOKEN` across all four reusable build templates.

## Why

As part of SEC-2026-002 the org-level `GH_TOKEN` was re-scoped to a fine-grained sync-workflows token (Contents / Workflows / Pull requests R+W, Metadata read) with **no `read:packages` scope**. Every Docker build step that installs private `@tazama-lf` packages via `secrets.GH_TOKEN` now 403s on `npm ci`.

`GH_TOKEN_LIB` is the dedicated `read:packages` token and is the correct source for package authentication. `GH_TOKEN` is intentionally left un-broadened.

## Change

Only the **value source** changes (`secrets.GH_TOKEN` -> `secrets.GH_TOKEN_LIB`). The BuildKit mount id and the env var name remain `GH_TOKEN`, so no Dockerfile or `.npmrc` changes are required in consumer repos.

Six mounts across four templates:

| Template | Mounts |
|---|---|
| `dockerhub-image-build.yml` (single, main) | 1 |
| `dockerhub-image-build-rc.yml` (single, rc) | 1 |
| `dockerhub-image-build-dual.yml` | 2 (backend + frontend) |
| `dockerhub-image-build-dual-rc.yml` | 2 (backend + frontend) |

The `env: GH_TOKEN: ${{ github.token }}` lines (gh CLI "Resolve source PR" steps) use the automatic Actions token and are **not** touched.

## Verification

- 6 `GH_TOKEN_LIB` mounts present, 0 stale `secrets.GH_TOKEN` mounts remain.
- 6 `github.token` env lines untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing workflows to use a different GitHub token source during builds.
  * Build and release steps remain unchanged, with no impact on image tags, notifications, or deployment flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->