### PR TITLE
fix(ci): pin RC reusable workflow checkouts to dev

### DIFF
--- a/.github/workflows/dockerhub-image-build-dual-rc.yml
+++ b/.github/workflows/dockerhub-image-build-dual-rc.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
@@ -109,6 +111,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121

--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout rule repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0

--- a/workflow-docs/dockerhub-image-build-dual-rc.md
+++ b/workflow-docs/dockerhub-image-build-dual-rc.md
@@ -32,7 +32,7 @@ Builds two Docker images - one for the `backend` subdirectory and one for the `f
 
 **Steps:**
 
-1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` - checks out source
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`ref: dev`) - checks out the `dev` (rc) line
 2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
 3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
 4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-backend`
@@ -44,7 +44,7 @@ Builds two Docker images - one for the `backend` subdirectory and one for the `f
 
 **Steps:**
 
-1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` - checks out source
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`ref: dev`) - checks out the `dev` (rc) line
 2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
 3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
 4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=rc`; image name: `tazamaorg/<REPO_NAME>-frontend`
@@ -92,6 +92,7 @@ Builds two Docker images - one for the `backend` subdirectory and one for the `f
 
 - The two jobs (`push_backend_rc` and `push_frontend_rc`) run in parallel and are independent. A failure in one does not cancel the other.
 - The `:rc` tag is a floating pointer overwritten on every push to `dev`. Use a version-pinned prerelease tag for reproducible deployments.
+- Both checkout steps are pinned to `ref: dev` so a manual `workflow_dispatch` always builds the `dev` line. `actions/checkout` otherwise defaults to the triggering ref, which after the default-branch pivot to `main` would build stable code and mislabel it with the `:rc` tag. Do not remove the `ref: dev` pin.
 - `dependabot[bot]` actors are excluded from both jobs.
 
 ---

--- a/workflow-docs/dockerhub-image-build-rc.md
+++ b/workflow-docs/dockerhub-image-build-rc.md
@@ -32,7 +32,7 @@ Builds a Docker image and pushes it to Docker Hub with a floating `:rc` tag when
 
 **Steps:**
 
-1. `actions/checkout@v4` - checks out source
+1. `actions/checkout@v4` (`ref: dev`) - checks out the `dev` (rc) line
 2. `docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121` - authenticates to Docker Hub
 3. `Set ENV variables` - derives `REPO_NAME` from `GITHUB_REPOSITORY`
 4. `docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf` - generates tag: `type=raw,value=rc`
@@ -77,6 +77,7 @@ Builds a Docker image and pushes it to Docker Hub with a floating `:rc` tag when
 ## Known Limitations / Notes
 
 - The `:rc` tag is a floating pointer overwritten on every push to `dev`. Use a version-pinned prerelease tag (e.g. `1.2.3-rc.4`) for reproducible deployments.
+- The checkout step is pinned to `ref: dev` so a manual `workflow_dispatch` always builds the `dev` line. `actions/checkout` otherwise defaults to the triggering ref, which after the default-branch pivot to `main` would build stable code and mislabel it with the `:rc` tag. Do not remove the `ref: dev` pin.
 - `dependabot[bot]` actors are excluded.
 
 ---

--- a/workflow-docs/package-rule-rc.md
+++ b/workflow-docs/package-rule-rc.md
@@ -43,7 +43,7 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 
 **Steps:**
 
-1. `actions/checkout@v4` - checks out rule repo source
+1. `actions/checkout@v4` (`ref: dev`) - checks out the rule repo `dev` (rc) line
 2. `actions/setup-node@v4` - Node 22
 3. `Read rule version from package.json` - reads `version`; fails if version is NOT a prerelease (`-` suffix required - guards against RC build running on a stable version)
 4. `Clone Rule Executer repository (dev branch)` - clones `tazama-lf/rule-executer@dev`
@@ -88,7 +88,7 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 
 - `dependabot[bot]` actors are excluded.
 - Rule repo caller stubs also trigger on `repository_dispatch: types: [rule-executer-update]`, enabling rule images to be rebuilt when `rule-executer` itself changes without needing a new commit in the rule repo.
-- The `:rc` tag is a floating pointer overwritten on every push to `dev`. Use the versioned tag (e.g. `1.0.0-rc.2`) for reproducible deployments.
+- The checkout step is pinned to `ref: dev`. RC builds must always read the rc line, but `actions/checkout` defaults to the ref that triggered the run - and under `repository_dispatch` (and `workflow_dispatch` once the default branch is `main`) that fallback is the repository default branch, not `dev`. Consumer rule repos pivoted their default branch from `dev` to `main`, so without the explicit `ref: dev` a dispatch-triggered run checked out `main` (a stable version) and failed the prerelease guard. Do not remove the `ref: dev` pin.
 
 ---
 


### PR DESCRIPTION
## What

Pin every release-candidate reusable workflow's checkout step to `ref: dev` so RC builds always read the rc line regardless of trigger or repository default branch.

Resolves the regression described in #147.

## Why

RC build workflows used a bare `actions/checkout` with no `ref:`. `actions/checkout` defaults to the ref that triggered the run; under `repository_dispatch` (and `workflow_dispatch` once the default branch is `main`) that fallback is the repository default branch. Consumer rule repos pivoted their default branch from `dev` to `main`, so dispatch-triggered RC builds started checking out the stable `main` line instead of `dev`:

- `package-rule-rc.yml`: the `rule-executer` push-to-dev flow dispatches `rule-executer-update` at `rule-901`/`rule-902`; the checkout resolved to `main` (a stable `3.0.0` version), which failed the prerelease guard in the "Read rule version from package.json" step with `exit 1`.
- `dockerhub-image-build-rc.yml` / `dockerhub-image-build-dual-rc.yml`: a manual `workflow_dispatch` would build the stable `main` source and publish it under the floating `:rc` tag.

## Changes

- `.github/workflows/package-rule-rc.yml` - `Checkout rule repository` -> `ref: dev`
- `.github/workflows/dockerhub-image-build-rc.yml` - `Check out the repo` -> `ref: dev`
- `.github/workflows/dockerhub-image-build-dual-rc.yml` - backend and frontend `Check out the repo` -> `ref: dev`
- Docs: recorded the pin and rationale in the three affected `workflow-docs/*.md`

## Not changed (deliberate)

- `package-rule.yml` (stable): reads the `main` line; default-branch fallback already resolves to `main`.
- `dockerhub-image-build.yml` / `dockerhub-image-build-dual.yml` (stable): triggered by `push: main` and `release: [published]`. The `release` trigger relies on `actions/checkout` defaulting to the released tag - pinning to `main` would break tag-accurate release builds, so they are intentionally left bare.
- `release.yml`, `release-train.yml`, `library-dependency-rollout.yml`: already pin an explicit `ref`.

## Replication

`frmscoe/workflows` mirrors the reusable rule workflows and is not part of `sync-workflows.yml`, so the equivalent fix is applied there via a separate manual PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release-candidate build workflows now consistently check out the intended development branch, avoiding accidental builds from the default branch.
  * This helps ensure RC images are labeled from the correct codebase during manual and automated runs.

* **Documentation**
  * Updated workflow docs to clarify the branch used for RC builds and note the importance of keeping that branch selection in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->