### PR TITLE
fix(ci): only enforce RC publish source-branch guard on push

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -179,8 +179,12 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/dev" ]]; then
-            echo "::error::RC images must be published from dev. Refusing to push from $GITHUB_REF."
+          # On push, GITHUB_REF is the pushed branch and must be dev. For
+          # repository_dispatch and workflow_dispatch the checkout above is pinned
+          # to ref: dev, so the dev line is always what gets built regardless of the
+          # trigger ref (which resolves to the repository default branch).
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" != "refs/heads/dev" ]]; then
+            echo "::error::RC images must be published from the dev line. Refusing to push from $GITHUB_REF."
             exit 1
           fi
 

--- a/workflow-docs/package-rule-rc.md
+++ b/workflow-docs/package-rule-rc.md
@@ -89,6 +89,7 @@ Called from a caller stub `package-rule-rc.yml` in each rule repo rather than be
 - `dependabot[bot]` actors are excluded.
 - Rule repo caller stubs also trigger on `repository_dispatch: types: [rule-executer-update]`, enabling rule images to be rebuilt when `rule-executer` itself changes without needing a new commit in the rule repo.
 - The checkout step is pinned to `ref: dev`. RC builds must always read the rc line, but `actions/checkout` defaults to the ref that triggered the run - and under `repository_dispatch` (and `workflow_dispatch` once the default branch is `main`) that fallback is the repository default branch, not `dev`. Consumer rule repos pivoted their default branch from `dev` to `main`, so without the explicit `ref: dev` a dispatch-triggered run checked out `main` (a stable version) and failed the prerelease guard. Do not remove the `ref: dev` pin.
+- The "Build and push RC Docker image" step's source-branch guard only applies to `push` events. Because the checkout is pinned to `ref: dev`, `repository_dispatch` and `workflow_dispatch` runs always build the dev line even though their `GITHUB_REF` resolves to the default branch (`main`); guarding those events on `GITHUB_REF` would incorrectly refuse the dispatch-triggered rebuilds.
 
 ---
 


### PR DESCRIPTION
## What

Gate the RC "Build and push RC Docker image" source-branch guard on `push` events only, so `repository_dispatch` and `workflow_dispatch` RC rebuilds are no longer refused.

Follow-up to #148; second instance of the regression tracked in #147.

## Why

The push step refused to publish unless `GITHUB_REF == refs/heads/dev`:

```bash
if [[ "$GITHUB_REF" != "refs/heads/dev" ]]; then
  echo "::error::RC images must be published from dev. Refusing to push from $GITHUB_REF."
  exit 1
fi
```

`GITHUB_REF` is the trigger ref. Under `repository_dispatch` (and `workflow_dispatch` after the default-branch pivot to `main`) it resolves to the repository default branch, now `main`. So the `rule-executer` -> `rule-901`/`rule-902` dispatch rebuilds failed at the push step with `RC images must be published from dev. Refusing to push from refs/heads/main` - even though #148 fixed the earlier version-guard failure.

Observed: https://github.com/tazama-lf/rule-901/actions/runs/28662369106

## Fix

The checkout is already pinned to `ref: dev` (from #148), so the dev line is always what gets built regardless of trigger. Enforce the source-branch guard on `push` only, where `GITHUB_REF` is the meaningful pushed branch; allow `repository_dispatch` and `workflow_dispatch`:

```bash
if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" != "refs/heads/dev" ]]; then
  echo "::error::RC images must be published from the dev line. Refusing to push from $GITHUB_REF."
  exit 1
fi
```

## Not changed (deliberate)

- `package-rule.yml` (stable): its mirror guard requires `refs/heads/main`. The stable caller stub triggers on `push: main` + `workflow_dispatch`, and the default branch is `main`, so `GITHUB_REF` already aligns - not affected.

## Replication

Mirrored to `frmscoe/workflows` (identical guard) via a separate PR.
